### PR TITLE
Enhance dark mode with analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Dieses Plugin stellt eine komplett deutschsprachige Lösung zur Verwaltung digit
 * Taxonomie für Kategorien mit individuellen Designoptionen
 * Suchfeld für Speisen im Frontend ohne Neuladen
 * Shortcode `[speisekarte]` mit Spalten- und Kategorieparametern
-* Dark-/Light-Switcher im Frontend
+* Dark-/Light-Switcher im Frontend inkl. Tastenkombi **Strg+Alt+D**
+* Zählt jede Umschaltung im Dashboard
 
 Die wichtigsten Dateien befinden sich im Plugin-Verzeichnis:
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -20,6 +20,10 @@ class AIO_Restaurant_Plugin {
         add_shortcode( 'speisekarte', array( $this, 'speisekarte_shortcode' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
         add_action( 'admin_enqueue_scripts', array( $this, 'admin_assets' ) );
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'wp_ajax_aorp_toggle_dark', array( $this, 'ajax_toggle_dark' ) );
+        add_action( 'wp_ajax_nopriv_aorp_toggle_dark', array( $this, 'ajax_toggle_dark' ) );
+        add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widgets' ) );
     }
 
     public function register_post_type() {
@@ -247,12 +251,32 @@ class AIO_Restaurant_Plugin {
         if ( ! is_admin() ) {
             wp_enqueue_style( 'aorp-style', plugin_dir_url( __FILE__ ) . 'assets/style.css' );
             wp_enqueue_script( 'aorp-script', plugin_dir_url( __FILE__ ) . 'assets/script.js', array('jquery'), false, true );
+            wp_localize_script( 'aorp-script', 'aorp_ajax', array( 'url' => admin_url( 'admin-ajax.php' ) ) );
         }
     }
 
     public function admin_assets() {
         wp_enqueue_style( 'wp-color-picker' );
         wp_enqueue_script( 'wp-color-picker' );
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain( 'aorp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    public function ajax_toggle_dark() {
+        $count = (int) get_option( 'aorp_dark_count', 0 );
+        update_option( 'aorp_dark_count', $count + 1 );
+        wp_send_json_success();
+    }
+
+    public function add_dashboard_widgets() {
+        wp_add_dashboard_widget( 'aorp_dashboard', 'Dark-Mode Umschaltungen', array( $this, 'dashboard_widget_output' ) );
+    }
+
+    public function dashboard_widget_output() {
+        $count = (int) get_option( 'aorp_dark_count', 0 );
+        echo '<p>Gesamtanzahl: <strong>' . $count . '</strong></p>';
     }
 }
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -30,14 +30,34 @@ jQuery(document).ready(function($){
     });
 
     if($('#aorp-toggle').length===0){
-        $('body').append('<div id="aorp-toggle">🌓</div>');
+        $('body').append('<div id="aorp-toggle" aria-label="Dark Mode umschalten" role="button" tabindex="0">🌓</div>');
+    }
+
+    function setDark(active){
+        if(active){
+            $('body').addClass('aorp-dark');
+            localStorage.setItem('aorp-dark-mode','on');
+        }else{
+            $('body').removeClass('aorp-dark');
+            localStorage.setItem('aorp-dark-mode','off');
+        }
+        $.post(aorp_ajax.url,{action:'aorp_toggle_dark'});
     }
 
     $('#aorp-toggle').on('click', function(){
-        $('body').toggleClass('aorp-dark');
+        setDark(!$('body').hasClass('aorp-dark'));
     });
 
-    if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
-        $('body').addClass('aorp-dark');
+    $(document).on('keydown', function(e){
+        if(e.ctrlKey && e.altKey && e.key.toLowerCase()=='d'){
+            setDark(!$('body').hasClass('aorp-dark'));
+        }
+    });
+
+    var stored = localStorage.getItem('aorp-dark-mode');
+    if(stored){
+        setDark(stored==='on');
+    }else if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
+        setDark(true);
     }
 });

--- a/languages/aorp.pot
+++ b/languages/aorp.pot
@@ -1,0 +1,4 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"


### PR DESCRIPTION
## Summary
- track dark mode usage via AJAX and show counter on dashboard
- store user preference in LocalStorage and toggle with keyboard
- load plugin textdomain for translations
- document analytics and keyboard shortcut in README

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855464d36548329bdf336b77bac84e1