### PR TITLE
Erweitere Plugin um Lightswitcher-Shortcode und CSV Import/Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Dieses Plugin stellt eine komplett deutschsprachige Lösung zur Verwaltung digit
 * Taxonomie für Kategorien mit individuellen Designoptionen
 * Suchfeld für Speisen im Frontend ohne Neuladen
 * Shortcode `[speisekarte]` mit Spalten- und Kategorieparametern
+* Shortcode `[restaurant_lightswitcher]` platziert den Dark‑Mode‑Schalter frei
+* Import/Export der Speisekarte als CSV im Admin-Menü "Speisekarte"
 * Dark-/Light-Switcher im Frontend inkl. Tastenkombi **Strg+Alt+D**
 * Zählt jede Umschaltung im Dashboard
 


### PR DESCRIPTION
## Summary
- erweitere Pluginbeschreibung
- erhöhe Version auf 1.1.0
- implementiere Shortcode `[restaurant_lightswitcher]`
- baue Administrationsseite für CSV Import/Export
- dokumentiere neue Funktionen

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855474e85488329bc9a54e65e0dcefe