### PR TITLE
Simplify admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.1.2
+Version: 1.1.3
 Autor: Dein Name
 
 ## Übersicht
@@ -12,12 +12,14 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 3. Inhaltsstoff-Legende
 4. Import/Export & Historie
 5. Widgets für Speisekarte und Lightswitcher
+6. Einfache Verwaltung aller Daten auf einer Seite
 
 ## Installation
 
 1. ZIP hochladen über Plugins → Installieren → Plugin hochladen  
 2. Plugin aktivieren  
-3. Unter Speisekarte im Admin erste Kategorien, Speisen und Legenden-Items anlegen
+3. Alle Kategorien, Speisen und Legenden-Items lassen sich unter
+   "Speisekarte → Verwaltung" bequem anlegen und bearbeiten
 
 ## Shortcodes
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: All-In-One WordPress Restaurant Plugin
 Description: Umfangreiches Speisekarten-Plugin mit Dark‑Mode, Suchfunktion und Import/Export.
-Version: 1.1.2
+Version: 1.1.3
 Author: stb-srv
 */
 
@@ -45,7 +45,8 @@ class AIO_Restaurant_Plugin {
         );
         register_post_type( 'aorp_menu_item', array(
             'labels' => $labels,
-            'public' => true,
+            'public' => false,
+            'show_ui' => false,
             'has_archive' => false,
             'supports' => array( 'title', 'editor', 'thumbnail' )
         ) );
@@ -59,8 +60,7 @@ class AIO_Restaurant_Plugin {
         register_post_type( 'aorp_legend', array(
             'labels' => $labels,
             'public' => false,
-            'show_ui' => true,
-            'show_in_menu' => 'edit.php?post_type=aorp_menu_item',
+            'show_ui' => false,
             'supports' => array( 'title', 'page-attributes' )
         ) );
     }
@@ -74,6 +74,7 @@ class AIO_Restaurant_Plugin {
             'labels' => $labels,
             'hierarchical' => true,
             'show_admin_column' => true,
+            'show_ui' => false,
         ) );
         // Term Meta for Styling
         add_action( 'aorp_menu_category_add_form_fields', array( $this, 'add_category_fields' ) );


### PR DESCRIPTION
## Summary
- hide custom post types and taxonomy from the WordPress admin UI
- document single page management
- bump plugin version

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68555489d88083299ba6ee78000db2d6