### PR TITLE
Add item overview with editing, deletion and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 3. Inhaltsstoff-Legende
 4. Import/Export & Historie
 5. Widgets für Speisekarte und Lightswitcher
-6. Einfache Verwaltung aller Daten auf einer Seite
+6. Einfache Verwaltung aller Daten auf einer Seite inklusive Bearbeiten und Löschen von Speisen sowie Filterfunktion
 
 ## Installation
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,22 @@
+jQuery(document).ready(function($){
+    $('#aorp-item-filter').on('keyup', function(){
+        var val = $(this).val().toLowerCase();
+        $('#aorp-items-table tbody tr').each(function(){
+            var text = $(this).text().toLowerCase();
+            $(this).toggle(text.indexOf(val) !== -1);
+        });
+    });
+
+    $('.aorp-ing-select').on('change', function(){
+        var ing = $(this).val();
+        if(ing){
+            var textarea = $(this).closest('form').find('.aorp-ing-text');
+            var current = textarea.val();
+            if(current){
+                current += ', ';
+            }
+            textarea.val(current + ing);
+            $(this).val('');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add administration JS helpers
- provide item editing/deleting/filtering in admin page
- expose new actions for update/delete
- load admin JS only on plugin pages
- update README

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `node -c assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_685555e257908329aef6528229dde8a7