### PR TITLE
Add category editing and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.1.3
+Version: 1.1.4
 Autor: Dein Name
 
 ## Übersicht
@@ -13,6 +13,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 4. Import/Export & Historie
 5. Widgets für Speisekarte und Lightswitcher
 6. Einfache Verwaltung aller Daten auf einer Seite inklusive Bearbeiten und Löschen von Speisen sowie Filterfunktion
+7. Kategorien besitzen Code und Bezeichnung und lassen sich filtern und bearbeiten
 
 ## Installation
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -7,6 +7,14 @@ jQuery(document).ready(function($){
         });
     });
 
+    $('#aorp-cat-filter').on('keyup', function(){
+        var val = $(this).val().toLowerCase();
+        $('#aorp-cat-table tbody tr').each(function(){
+            var text = $(this).text().toLowerCase();
+            $(this).toggle(text.indexOf(val) !== -1);
+        });
+    });
+
     $('.aorp-ing-select').on('change', function(){
         var ing = $(this).val();
         if(ing){


### PR DESCRIPTION
## Summary
- add Code field to categories
- show category edit and filter table in admin
- support updating and deleting categories
- implement category filter in admin JS
- bump version to 1.1.4

## Testing
- `php` commands were unavailable; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6855571034a88329890a483d07b77cae