### PR TITLE
Improve YAML import error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.1.5
+Version: 1.1.6
 Autor: Dein Name
 
 ## Übersicht


### PR DESCRIPTION
## Summary
- add admin notices to show import errors
- provide success and error messages for JSON/YAML import
- update plugin and README version to 1.1.6

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `apt-get update`
- `apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_e_68556b2dafb48329a1e028fdc2177560