### PR TITLE
Add settings page and bulk selection features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 5. Einfache Verwaltung aller Daten auf einer Seite inklusive Bearbeiten und Löschen von Speisen sowie Filterfunktion
 6. Kategorien besitzen Code und Bezeichnung und lassen sich filtern und bearbeiten
 7. Import/Export berücksichtigt Kategorien, Inhaltsstoffe und weitere Einstellungen
+8. Spaltenanzahl der Speisekarte (1–3) über Einstellungen wählbar
 
 ## Installation
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -93,4 +93,13 @@ jQuery(document).ready(function($){
         });
         aorp_frame.open();
     });
+
+    $('.aorp-select-all').on('click', function(e){
+        e.preventDefault();
+        $($(this).data('target')).prop('checked', true);
+    });
+    $('.aorp-unselect-all').on('click', function(e){
+        e.preventDefault();
+        $($(this).data('target')).prop('checked', false);
+    });
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -18,3 +18,14 @@ body.aorp-dark .aorp-category{background:#333;color:#fff}
 .aorp-selected{margin-bottom:.5em}
 .aorp-ing-chip{background:#eee;padding:2px 5px;margin-right:4px;display:inline-block;border-radius:3px}
 .aorp-ing-chip a{text-decoration:none;margin-left:3px}
+
+@media (max-width:600px){
+    .columns-2 .aorp-category,
+    .columns-3 .aorp-category,
+    .columns-2 .aorp-items,
+    .columns-3 .aorp-items{
+        width:100%;
+        float:none;
+        margin-right:0;
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring menu columns in new settings page
- default `[speisekarte]` shortcode columns value to settings
- add select-all/unselect-all buttons for bulk actions
- enable responsive single-column layout on small screens
- update README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68556deee2ec8329996ca8fece528452