### PR TITLE
Add live preview for font sizes

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -634,7 +634,7 @@ class AIO_Restaurant_Plugin {
                 <h2>Darstellung</h2>
                 <table class="form-table">
                     <tr>
-                        <th scope="row"><label for="aorp_size_number">Schriftgröße Nummer</label></th>
+                        <th scope="row"><label for="aorp_size_number">Schriftgröße Nummer (1em)</label></th>
                         <td>
                             <select name="aorp_size_number" id="aorp_size_number">
                                 <?php foreach ( $sizes as $s ) : ?>
@@ -644,7 +644,7 @@ class AIO_Restaurant_Plugin {
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="aorp_size_title">Schriftgröße Titel</label></th>
+                        <th scope="row"><label for="aorp_size_title">Schriftgröße Titel (1em)</label></th>
                         <td>
                             <select name="aorp_size_title" id="aorp_size_title">
                                 <?php foreach ( $sizes as $s ) : ?>
@@ -654,7 +654,7 @@ class AIO_Restaurant_Plugin {
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="aorp_size_desc">Schriftgröße Beschreibung</label></th>
+                        <th scope="row"><label for="aorp_size_desc">Schriftgröße Beschreibung (0.9em)</label></th>
                         <td>
                             <select name="aorp_size_desc" id="aorp_size_desc">
                                 <?php foreach ( $sizes as $s ) : ?>
@@ -664,7 +664,7 @@ class AIO_Restaurant_Plugin {
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="aorp_size_price">Schriftgröße Preis</label></th>
+                        <th scope="row"><label for="aorp_size_price">Schriftgröße Preis (1em)</label></th>
                         <td>
                             <select name="aorp_size_price" id="aorp_size_price">
                                 <?php foreach ( $sizes as $s ) : ?>

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -102,4 +102,16 @@ jQuery(document).ready(function($){
         e.preventDefault();
         $($(this).data('target')).prop('checked', false);
     });
+
+    // Live preview for font size settings on the settings page
+    if($('#aorp_size_number').length){
+        function aorpUpdatePreview(){
+            $('.aorp-number').css('font-size', $('#aorp_size_number').val() || '');
+            $('.aorp-title').css('font-size', $('#aorp_size_title').val() || '');
+            $('.aorp-desc').css('font-size', $('#aorp_size_desc').val() || '');
+            $('.aorp-price').css('font-size', $('#aorp_size_price').val() || '');
+        }
+        $('#aorp_size_number,#aorp_size_title,#aorp_size_desc,#aorp_size_price').on('change', aorpUpdatePreview);
+        aorpUpdatePreview();
+    }
 });


### PR DESCRIPTION
## Summary
- support live preview of font sizes on the settings page
- show default sizes next to font dropdown labels

## Testing
- `npm test` *(fails: Could not find package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685589ba99888329bcc31afdd65d18a2