### PR TITLE
Add icon tab in Dark Mode settings

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -678,20 +678,29 @@ class AIO_Restaurant_Plugin {
                 </table>
 
                 <h2>Dark Mode</h2>
-                <?php
-                    $icon_light = get_option( 'aorp_icon_light', '☀️' );
-                    $icon_dark  = get_option( 'aorp_icon_dark', '🌙' );
-                ?>
-                <table class="form-table">
-                    <tr>
-                        <th scope="row"><label for="aorp_icon_light">Symbol hell</label></th>
-                        <td><input type="text" name="aorp_icon_light" id="aorp_icon_light" value="<?php echo esc_attr( $icon_light ); ?>" class="regular-text" /></td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="aorp_icon_dark">Symbol dunkel</label></th>
-                        <td><input type="text" name="aorp_icon_dark" id="aorp_icon_dark" value="<?php echo esc_attr( $icon_dark ); ?>" class="regular-text" /></td>
-                    </tr>
-                </table>
+                <div class="nav-tab-wrapper" id="aorp-dark-tabs">
+                    <a href="#aorp-dark-general" class="nav-tab nav-tab-active">Allgemein</a>
+                    <a href="#aorp-dark-icon" class="nav-tab">Icon</a>
+                </div>
+                <div id="aorp-dark-general" class="aorp-dark-tab" style="display:block;">
+                    <p><?php esc_html_e( 'Keine weiteren Einstellungen.', 'aorp' ); ?></p>
+                </div>
+                <div id="aorp-dark-icon" class="aorp-dark-tab" style="display:none;">
+                    <?php
+                        $icon_light = get_option( 'aorp_icon_light', '☀️' );
+                        $icon_dark  = get_option( 'aorp_icon_dark', '🌙' );
+                    ?>
+                    <table class="form-table">
+                        <tr>
+                            <th scope="row"><label for="aorp_icon_light">Symbol hell</label></th>
+                            <td><input type="text" name="aorp_icon_light" id="aorp_icon_light" value="<?php echo esc_attr( $icon_light ); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="aorp_icon_dark">Symbol dunkel</label></th>
+                            <td><input type="text" name="aorp_icon_dark" id="aorp_icon_dark" value="<?php echo esc_attr( $icon_dark ); ?>" class="regular-text" /></td>
+                        </tr>
+                    </table>
+                </div>
                 <?php submit_button(); ?>
             </form>
             <?php $this->output_custom_styles(); ?>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -7,3 +7,10 @@
 .aorp-section h2 {
     margin-top: 0;
 }
+
+#aorp-dark-tabs .nav-tab {
+    cursor: pointer;
+}
+.aorp-dark-tab {
+    padding: 10px 0;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -114,4 +114,14 @@ jQuery(document).ready(function($){
         $('#aorp_size_number,#aorp_size_title,#aorp_size_desc,#aorp_size_price').on('change', aorpUpdatePreview);
         aorpUpdatePreview();
     }
+
+    if($('#aorp-dark-tabs').length){
+        $('#aorp-dark-tabs .nav-tab').on('click', function(e){
+            e.preventDefault();
+            $('#aorp-dark-tabs .nav-tab').removeClass('nav-tab-active');
+            $(this).addClass('nav-tab-active');
+            $('.aorp-dark-tab').hide();
+            $($(this).attr('href')).show();
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- add tabs for Dark Mode settings section
- move icon options into new "Icon" tab
- style tab and add JS logic for toggling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68558fe92cf08329b1b7d99b8b439ad6