### PR TITLE
Add Dark Mode settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 - [restaurant_lightswitcher] – Dark Mode Switcher
 Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verwendet werden.
 
+## Dark‑Mode Icons
+
+Unter "Speisekarte → Dark Mode" lassen sich verschiedene Icon-Sets per Dropdown auswählen. 
+Alternativ können eigene Icons (PNG, 32x32 Pixel, transparenter Hintergrund) hochgeladen werden. 
+Kostenlose Icons findest du z.B. auf [flaticon.com](https://www.flaticon.com).
+

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -124,4 +124,22 @@ jQuery(document).ready(function($){
             $($(this).attr('href')).show();
         });
     }
+
+    if($('#aorp_icon_set').length){
+        function updateIconFields(){
+            var set = $('#aorp_icon_set').val();
+            if(set==='custom') return;
+            var map = {
+                'default':['☀️','🌙'],
+                'alt':['🌞','🌜'],
+                'minimal':['🔆','🌑']
+            };
+            if(map[set]){
+                $('#aorp_icon_light').val(map[set][0]);
+                $('#aorp_icon_dark').val(map[set][1]);
+            }
+        }
+        $('#aorp_icon_set').on('change',updateIconFields);
+        updateIconFields();
+    }
 });

--- a/assets/script.js
+++ b/assets/script.js
@@ -32,17 +32,17 @@ jQuery(document).ready(function($){
     if($('#aorp-toggle').length===0){
         $('body').append('<div id="aorp-toggle" aria-label="Dark Mode umschalten" role="button" tabindex="0">'+aorp_ajax.icon_light+'</div>');
     } else {
-        $('#aorp-toggle').text(aorp_ajax.icon_light);
+        $('#aorp-toggle').html(aorp_ajax.icon_light);
     }
 
     function setDark(active){
         if(active){
             $('body').addClass('aorp-dark');
-            $('#aorp-toggle').text(aorp_ajax.icon_dark);
+            $('#aorp-toggle').html(aorp_ajax.icon_dark);
             localStorage.setItem('aorp-dark-mode','on');
         }else{
             $('body').removeClass('aorp-dark');
-            $('#aorp-toggle').text(aorp_ajax.icon_light);
+            $('#aorp-toggle').html(aorp_ajax.icon_light);
             localStorage.setItem('aorp-dark-mode','off');
         }
         $.post(aorp_ajax.url,{action:'aorp_toggle_dark'});


### PR DESCRIPTION
## Summary
- enable custom or predefined icons for Dark Mode
- move Dark Mode options to a dedicated admin page
- support icon uploads and allow choosing predefined sets
- update JavaScript to handle icons as HTML
- document custom icon usage in README

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685591edafb083298ad04a680a40bc59