### PR TITLE
Add Dark Mode top-level menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verw
 
 ## Dark‑Mode Icons
 
-Unter "Speisekarte → Dark Mode" lassen sich verschiedene Icon-Sets per Dropdown auswählen. 
+Unter "Dark Mode" im Hauptmenü lassen sich verschiedene Icon-Sets per Dropdown auswählen.
 Alternativ können eigene Icons (PNG, 32x32 Pixel, transparenter Hintergrund) hochgeladen werden. 
 Kostenlose Icons findest du z.B. auf [flaticon.com](https://www.flaticon.com).
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -597,7 +597,7 @@ class AIO_Restaurant_Plugin {
         add_menu_page( 'Speisekarte', 'Speisekarte', 'manage_options', 'aorp_manage', array( $this, 'manage_page' ), 'dashicons-list-view' );
         add_submenu_page( 'aorp_manage', 'Import/Export', 'Import/Export', 'manage_options', 'aorp_export', array( $this, 'export_page' ) );
         add_submenu_page( 'aorp_manage', 'Einstellungen', 'Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'settings_page' ) );
-        add_submenu_page( 'aorp_manage', 'Dark Mode', 'Dark Mode', 'manage_options', 'aorp_dark', array( $this, 'dark_page' ) );
+        add_menu_page( 'Dark Mode', 'Dark Mode', 'manage_options', 'aorp_dark', array( $this, 'dark_page' ), 'dashicons-lightbulb' );
         // Historie wird direkt auf der Import/Export Seite angezeigt
     }
 


### PR DESCRIPTION
## Summary
- move Dark Mode settings from Speisekarte submenu to its own top-level menu
- update documentation accordingly

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685595044bfc832987ba4c8fe88fc4c0