### PR TITLE
Extend dark mode icon options

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -580,9 +580,19 @@ class AIO_Restaurant_Plugin {
             return esc_html( $char );
         } else {
             $sets = array(
-                'default' => array( '☀️', '🌙' ),
-                'alt'     => array( '🌞', '🌜' ),
-                'minimal' => array( '🔆', '🌑' ),
+                'default'  => array( '☀️', '🌙' ),
+                'alt'      => array( '🌞', '🌜' ),
+                'minimal'  => array( '🔆', '🌑' ),
+                'eclipse'  => array( '🌞', '🌚' ),
+                'sunset'   => array( '🌇', '🌃' ),
+                'cloudy'   => array( '⛅', '🌙' ),
+                'simple'   => array( '☼', '☾' ),
+                'twilight' => array( '🌄', '🌌' ),
+                'starry'   => array( '⭐', '🌜' ),
+                'morning'  => array( '🌅', '🌠' ),
+                'bright'   => array( '🔆', '🔅' ),
+                'flower'   => array( '🌻', '🌑' ),
+                'smiley'   => array( '😀', '😴' ),
             );
             if ( isset( $sets[ $set ] ) ) {
                 $index = $type === 'light' ? 0 : 1;
@@ -737,10 +747,20 @@ class AIO_Restaurant_Plugin {
                     $light_img  = intval( get_option( 'aorp_icon_light_img', 0 ) );
                     $dark_img   = intval( get_option( 'aorp_icon_dark_img', 0 ) );
                     $icon_sets  = array(
-                        'default' => array('☀️','🌙'),
-                        'alt'     => array('🌞','🌜'),
-                        'minimal' => array('🔆','🌑'),
-                        'custom'  => array('', '')
+                        'default'  => array('☀️','🌙'),
+                        'alt'      => array('🌞','🌜'),
+                        'minimal'  => array('🔆','🌑'),
+                        'eclipse'  => array('🌞','🌚'),
+                        'sunset'   => array('🌇','🌃'),
+                        'cloudy'   => array('⛅','🌙'),
+                        'simple'   => array('☼','☾'),
+                        'twilight' => array('🌄','🌌'),
+                        'starry'   => array('⭐','🌜'),
+                        'morning'  => array('🌅','🌠'),
+                        'bright'   => array('🔆','🔅'),
+                        'flower'   => array('🌻','🌑'),
+                        'smiley'   => array('😀','😴'),
+                        'custom'   => array('', '')
                     );
                 ?>
                 <table class="form-table">

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -132,7 +132,17 @@ jQuery(document).ready(function($){
             var map = {
                 'default':['☀️','🌙'],
                 'alt':['🌞','🌜'],
-                'minimal':['🔆','🌑']
+                'minimal':['🔆','🌑'],
+                'eclipse':['🌞','🌚'],
+                'sunset':['🌇','🌃'],
+                'cloudy':['⛅','🌙'],
+                'simple':['☼','☾'],
+                'twilight':['🌄','🌌'],
+                'starry':['⭐','🌜'],
+                'morning':['🌅','🌠'],
+                'bright':['🔆','🔅'],
+                'flower':['🌻','🌑'],
+                'smiley':['😀','😴']
             };
             if(map[set]){
                 $('#aorp_icon_light').val(map[set][0]);


### PR DESCRIPTION
## Summary
- expand icon options array in `get_icon_html`
- extend admin icon set dropdown
- sync icon set mapping in admin JS

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6855965ff1f08329a717a7b763b24442