### PR TITLE
Add selectable dark mode templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verw
 ## Dark‑Mode Icons
 
 Unter "Dark Mode" im Hauptmenü lassen sich verschiedene Icon-Sets per Dropdown auswählen.
-Alternativ können eigene Icons (PNG, 32x32 Pixel, transparenter Hintergrund) hochgeladen werden. 
+Ebenfalls steht dort eine Auswahl von zehn Templates bereit, um unterschiedliche Farbschemata des Dark Modes zu verwenden.
+Alternativ können eigene Icons (PNG, 32x32 Pixel, transparenter Hintergrund) hochgeladen werden.
 Kostenlose Icons findest du z.B. auf [flaticon.com](https://www.flaticon.com).
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -746,6 +746,7 @@ class AIO_Restaurant_Plugin {
                     $set        = get_option( 'aorp_icon_set', 'default' );
                     $light_img  = intval( get_option( 'aorp_icon_light_img', 0 ) );
                     $dark_img   = intval( get_option( 'aorp_icon_dark_img', 0 ) );
+                    $template   = intval( get_option( 'aorp_dark_template', 1 ) );
                     $icon_sets  = array(
                         'default'  => array('☀️','🌙'),
                         'alt'      => array('🌞','🌜'),
@@ -797,6 +798,16 @@ class AIO_Restaurant_Plugin {
                             <span class="aorp-image-preview"><?php echo $dark_img ? wp_get_attachment_image( $dark_img, array(32,32) ) : ''; ?></span>
                         </td>
                     </tr>
+                    <tr>
+                        <th scope="row"><label for="aorp_dark_template">Template</label></th>
+                        <td>
+                            <select name="aorp_dark_template" id="aorp_dark_template">
+                                <?php for ( $i = 1; $i <= 10; $i++ ) : ?>
+                                    <option value="<?php echo $i; ?>" <?php selected( $template, $i ); ?>><?php echo $i; ?></option>
+                                <?php endfor; ?>
+                            </select>
+                        </td>
+                    </tr>
                 </table>
                 <?php submit_button(); ?>
             </form>
@@ -818,6 +829,7 @@ class AIO_Restaurant_Plugin {
         register_setting( 'aorp_dark', 'aorp_icon_dark', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => '🌙' ) );
         register_setting( 'aorp_dark', 'aorp_icon_light_img', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 0 ) );
         register_setting( 'aorp_dark', 'aorp_icon_dark_img', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 0 ) );
+        register_setting( 'aorp_dark', 'aorp_dark_template', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 1 ) );
     }
 
     private function render_history_table() {
@@ -1057,6 +1069,7 @@ class AIO_Restaurant_Plugin {
                 'url'        => admin_url( 'admin-ajax.php' ),
                 'icon_light' => $this->get_icon_html( 'light' ),
                 'icon_dark'  => $this->get_icon_html( 'dark' ),
+                'template'   => intval( get_option( 'aorp_dark_template', 1 ) ),
             ) );
         }
     }

--- a/assets/script.js
+++ b/assets/script.js
@@ -35,13 +35,15 @@ jQuery(document).ready(function($){
         $('#aorp-toggle').html(aorp_ajax.icon_light);
     }
 
+    var templateClass = 'aorp-template-' + (aorp_ajax.template || 1);
+
     function setDark(active){
         if(active){
-            $('body').addClass('aorp-dark');
+            $('body').addClass('aorp-dark ' + templateClass);
             $('#aorp-toggle').html(aorp_ajax.icon_dark);
             localStorage.setItem('aorp-dark-mode','on');
         }else{
-            $('body').removeClass('aorp-dark');
+            $('body').removeClass('aorp-dark ' + templateClass);
             $('#aorp-toggle').html(aorp_ajax.icon_light);
             localStorage.setItem('aorp-dark-mode','off');
         }

--- a/assets/style.css
+++ b/assets/style.css
@@ -22,6 +22,26 @@
 #aorp-search{width:100%;padding:0.5em;margin:0}
 body.aorp-dark{background:#222;color:#eee}
 body.aorp-dark .aorp-category{background:#333;color:#fff}
+body.aorp-dark.aorp-template-1{background:#222;color:#eee}
+body.aorp-dark.aorp-template-1 .aorp-category{background:#333;color:#fff}
+body.aorp-dark.aorp-template-2{background:#111;color:#ddd}
+body.aorp-dark.aorp-template-2 .aorp-category{background:#222;color:#eee}
+body.aorp-dark.aorp-template-3{background:#000;color:#fff}
+body.aorp-dark.aorp-template-3 .aorp-category{background:#444;color:#fff}
+body.aorp-dark.aorp-template-4{background:#2b2b2b;color:#f5f5f5}
+body.aorp-dark.aorp-template-4 .aorp-category{background:#3b3b3b;color:#fff}
+body.aorp-dark.aorp-template-5{background:#1a1a1a;color:#e0e0e0}
+body.aorp-dark.aorp-template-5 .aorp-category{background:#444;color:#fff}
+body.aorp-dark.aorp-template-6{background:#121212;color:#e8e8e8}
+body.aorp-dark.aorp-template-6 .aorp-category{background:#242424;color:#fff}
+body.aorp-dark.aorp-template-7{background:#191919;color:#f0f0f0}
+body.aorp-dark.aorp-template-7 .aorp-category{background:#333;color:#fff}
+body.aorp-dark.aorp-template-8{background:#202020;color:#fafafa}
+body.aorp-dark.aorp-template-8 .aorp-category{background:#444;color:#fff}
+body.aorp-dark.aorp-template-9{background:#000;color:#e6e6e6}
+body.aorp-dark.aorp-template-9 .aorp-category{background:#333;color:#fff}
+body.aorp-dark.aorp-template-10{background:#141414;color:#e5e5e5}
+body.aorp-dark.aorp-template-10 .aorp-category{background:#2a2a2a;color:#fff}
 #aorp-toggle{position:fixed;bottom:20px;right:20px;cursor:pointer;padding:0.5em;background:#000;color:#fff;border-radius:3px;z-index:9999}
 .aorp-selected{margin-bottom:.5em}
 .aorp-ing-chip{background:#eee;padding:2px 5px;margin-right:4px;display:inline-block;border-radius:3px}


### PR DESCRIPTION
## Summary
- allow selecting between ten dark mode templates
- localize template selection for scripts
- switch templates in JS when dark mode toggles
- document new templates in README

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685597accbd0832996e7ae381ccb573f