### PR TITLE
Improve dark mode selection UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verw
 
 Unter "Dark Mode" im Hauptmenü lassen sich verschiedene Icon-Sets per Dropdown auswählen.
 Ebenfalls steht dort eine Auswahl von zehn Templates bereit, um unterschiedliche Farbschemata des Dark Modes zu verwenden.
+Die Templates sind bereits im Plugin enthalten und müssen nicht hochgeladen werden.
+Durch die neue Vorschau wird das aktuell gewählte Icon-Set sowie das Template direkt angezeigt.
 Alternativ können eigene Icons (PNG, 32x32 Pixel, transparenter Hintergrund) hochgeladen werden.
 Kostenlose Icons findest du z.B. auf [flaticon.com](https://www.flaticon.com).
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -773,6 +773,7 @@ class AIO_Restaurant_Plugin {
                                     <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $set, $key ); ?>><?php echo $key === 'custom' ? 'Eigene Icons' : esc_html( $icons[0] . ' / ' . $icons[1] ); ?></option>
                                 <?php endforeach; ?>
                             </select>
+                            <span id="aorp_icon_preview" class="aorp-icon-preview"><?php echo $set === 'custom' ? 'Eigenes Icon-Set' : esc_html( $icon_sets[ $set ][0] . ' / ' . $icon_sets[ $set ][1] ); ?></span>
                         </td>
                     </tr>
                     <tr style="display:none;">
@@ -806,6 +807,26 @@ class AIO_Restaurant_Plugin {
                                     <option value="<?php echo $i; ?>" <?php selected( $template, $i ); ?>><?php echo $i; ?></option>
                                 <?php endfor; ?>
                             </select>
+                            <div id="aorp_template_preview">
+                                <?php
+                                    $tpl_colors = array(
+                                        1  => array('bg' => '#222', 'text' => '#eee', 'cat' => '#333'),
+                                        2  => array('bg' => '#111', 'text' => '#ddd', 'cat' => '#222'),
+                                        3  => array('bg' => '#000', 'text' => '#fff', 'cat' => '#444'),
+                                        4  => array('bg' => '#2b2b2b', 'text' => '#f5f5f5', 'cat' => '#3b3b3b'),
+                                        5  => array('bg' => '#1a1a1a', 'text' => '#e0e0e0', 'cat' => '#444'),
+                                        6  => array('bg' => '#121212', 'text' => '#e8e8e8', 'cat' => '#242424'),
+                                        7  => array('bg' => '#191919', 'text' => '#f0f0f0', 'cat' => '#333'),
+                                        8  => array('bg' => '#202020', 'text' => '#fafafa', 'cat' => '#444'),
+                                        9  => array('bg' => '#000', 'text' => '#e6e6e6', 'cat' => '#333'),
+                                        10 => array('bg' => '#141414', 'text' => '#e5e5e5', 'cat' => '#2a2a2a'),
+                                    );
+                                    for ( $i = 1; $i <= 10; $i++ ) {
+                                        $c = $tpl_colors[ $i ];
+                                        echo '<span class="aorp-template-swatch" data-template="' . $i . '" style="background:' . esc_attr( $c['bg'] ) . ';color:' . esc_attr( $c['text'] ) . ';border-color:' . esc_attr( $c['cat'] ) . '">' . $i . '</span> ';
+                                    }
+                                ?>
+                            </div>
                         </td>
                     </tr>
                 </table>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -14,3 +14,27 @@
 .aorp-dark-tab {
     padding: 10px 0;
 }
+
+#aorp_icon_preview {
+    margin-left: 10px;
+    font-size: 20px;
+}
+
+#aorp_template_preview {
+    margin-top: 5px;
+}
+
+.aorp-template-swatch {
+    display: inline-block;
+    width: 32px;
+    height: 24px;
+    line-height: 24px;
+    text-align: center;
+    margin-right: 4px;
+    border: 2px solid transparent;
+    cursor: pointer;
+}
+
+.aorp-template-swatch.selected {
+    border-color: #007cba;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -147,9 +147,25 @@ jQuery(document).ready(function($){
             if(map[set]){
                 $('#aorp_icon_light').val(map[set][0]);
                 $('#aorp_icon_dark').val(map[set][1]);
+                $('#aorp_icon_preview').text(map[set][0]+' / '+map[set][1]);
+            } else {
+                $('#aorp_icon_preview').text('Eigenes Icon-Set');
             }
         }
         $('#aorp_icon_set').on('change',updateIconFields);
         updateIconFields();
+    }
+
+    if($('#aorp_template_preview').length){
+        function updateTemplatePreview(){
+            var val = $('#aorp_dark_template').val();
+            $('.aorp-template-swatch').removeClass('selected');
+            $('.aorp-template-swatch[data-template='+val+']').addClass('selected');
+        }
+        $('#aorp_dark_template').on('change', updateTemplatePreview);
+        $('#aorp_template_preview').on('click', '.aorp-template-swatch', function(){
+            $('#aorp_dark_template').val($(this).data('template')).trigger('change');
+        });
+        updateTemplatePreview();
     }
 });


### PR DESCRIPTION
## Summary
- add live preview for icon set and template selection in Dark Mode settings
- clarify template usage in README

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559c930f2c83299e3f87ecdb2f788a