### PR TITLE
Remove dark mode templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,28 +54,11 @@ Zunächst wählst du ein passendes Icon-Set oder lädst eigene Symbole hoch. Ans
 | smiley    | 😀 / 😴 |
 | custom    | eigene Icons |
 
-### Templates (Farbschemata)
-
-Die Zahl 1–10 wählt jeweils ein vorbereitetes Farbschema. Eine kleine Vorschau zeigt dir die Farben an. Die Icons bleiben dabei unverändert.
-
-| Nr. | Hintergrund | Text | Kategorie |
-|----:|-------------|------|-----------|
-| 1 | `#222` | `#eee` | `#333` |
-| 2 | `#111` | `#ddd` | `#222` |
-| 3 | `#000` | `#fff` | `#444` |
-| 4 | `#2b2b2b` | `#f5f5f5` | `#3b3b3b` |
-| 5 | `#1a1a1a` | `#e0e0e0` | `#444` |
-| 6 | `#121212` | `#e8e8e8` | `#242424` |
-| 7 | `#191919` | `#f0f0f0` | `#333` |
-| 8 | `#202020` | `#fafafa` | `#444` |
-| 9 | `#000` | `#e6e6e6` | `#333` |
-| 10 | `#141414` | `#e5e5e5` | `#2a2a2a` |
-
 ### Eigene Icons hochladen
 
 1. Wähle im Dropdown **Icon Set** den Eintrag **Eigene Icons**.
 2. Klicke bei "Eigenes Icon hell" bzw. "Eigenes Icon dunkel" auf *Bild auswählen* und lade jeweils eine 32x32‑PNG mit transparentem Hintergrund hoch.
-3. Lege ein Template fest und speichere die Einstellungen.
+3. Speichere die Einstellungen.
 
 Kostenlose Icons findest du zum Beispiel auf [flaticon.com](https://www.flaticon.com).
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -740,8 +740,7 @@ class AIO_Restaurant_Plugin {
         ?>
         <div class="wrap">
             <h1>Dark Mode</h1>
-            <p class="description">Wähle zunächst ein Icon-Set oder lade eigene Icons hoch. 
-            Das darunterliegende Template bestimmt nur die Farben des Dark Modes – die ausgewählten Icons bleiben erhalten. 
+            <p class="description">Wähle zunächst ein Icon-Set oder lade eigene Icons hoch.
             Nach deinen Anpassungen klicke auf „Änderungen speichern“.</p>
             <form method="post" action="options.php">
                 <?php settings_fields( 'aorp_dark' ); ?>
@@ -749,7 +748,6 @@ class AIO_Restaurant_Plugin {
                     $set        = get_option( 'aorp_icon_set', 'default' );
                     $light_img  = intval( get_option( 'aorp_icon_light_img', 0 ) );
                     $dark_img   = intval( get_option( 'aorp_icon_dark_img', 0 ) );
-                    $template   = intval( get_option( 'aorp_dark_template', 1 ) );
                     $icon_sets  = array(
                         'default'  => array('☀️','🌙'),
                         'alt'      => array('🌞','🌜'),
@@ -802,36 +800,6 @@ class AIO_Restaurant_Plugin {
                             <span class="aorp-image-preview"><?php echo $dark_img ? wp_get_attachment_image( $dark_img, array(32,32) ) : ''; ?></span>
                         </td>
                     </tr>
-                    <tr>
-                        <th scope="row"><label for="aorp_dark_template">Farbvorlage (Template)</label></th>
-                        <td>
-                            <select name="aorp_dark_template" id="aorp_dark_template">
-                                <?php for ( $i = 1; $i <= 10; $i++ ) : ?>
-                                    <option value="<?php echo $i; ?>" <?php selected( $template, $i ); ?>><?php echo $i; ?></option>
-                                <?php endfor; ?>
-                            </select>
-                            <div id="aorp_template_preview">
-                                <?php
-                                    $tpl_colors = array(
-                                        1  => array('bg' => '#222', 'text' => '#eee', 'cat' => '#333'),
-                                        2  => array('bg' => '#111', 'text' => '#ddd', 'cat' => '#222'),
-                                        3  => array('bg' => '#000', 'text' => '#fff', 'cat' => '#444'),
-                                        4  => array('bg' => '#2b2b2b', 'text' => '#f5f5f5', 'cat' => '#3b3b3b'),
-                                        5  => array('bg' => '#1a1a1a', 'text' => '#e0e0e0', 'cat' => '#444'),
-                                        6  => array('bg' => '#121212', 'text' => '#e8e8e8', 'cat' => '#242424'),
-                                        7  => array('bg' => '#191919', 'text' => '#f0f0f0', 'cat' => '#333'),
-                                        8  => array('bg' => '#202020', 'text' => '#fafafa', 'cat' => '#444'),
-                                        9  => array('bg' => '#000', 'text' => '#e6e6e6', 'cat' => '#333'),
-                                        10 => array('bg' => '#141414', 'text' => '#e5e5e5', 'cat' => '#2a2a2a'),
-                                    );
-                                    for ( $i = 1; $i <= 10; $i++ ) {
-                                        $c = $tpl_colors[ $i ];
-                                        echo '<span class="aorp-template-swatch" data-template="' . $i . '" style="background:' . esc_attr( $c['bg'] ) . ';color:' . esc_attr( $c['text'] ) . ';border-color:' . esc_attr( $c['cat'] ) . '">' . $i . '</span> ';
-                                    }
-                                ?>
-                            </div>
-                        </td>
-                    </tr>
                 </table>
                 <?php submit_button(); ?>
             </form>
@@ -853,7 +821,6 @@ class AIO_Restaurant_Plugin {
         register_setting( 'aorp_dark', 'aorp_icon_dark', array( 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => '🌙' ) );
         register_setting( 'aorp_dark', 'aorp_icon_light_img', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 0 ) );
         register_setting( 'aorp_dark', 'aorp_icon_dark_img', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 0 ) );
-        register_setting( 'aorp_dark', 'aorp_dark_template', array( 'type' => 'integer', 'sanitize_callback' => 'absint', 'default' => 1 ) );
     }
 
     private function render_history_table() {
@@ -1093,7 +1060,6 @@ class AIO_Restaurant_Plugin {
                 'url'        => admin_url( 'admin-ajax.php' ),
                 'icon_light' => $this->get_icon_html( 'light' ),
                 'icon_dark'  => $this->get_icon_html( 'dark' ),
-                'template'   => intval( get_option( 'aorp_dark_template', 1 ) ),
             ) );
         }
     }

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -20,21 +20,3 @@
     font-size: 20px;
 }
 
-#aorp_template_preview {
-    margin-top: 5px;
-}
-
-.aorp-template-swatch {
-    display: inline-block;
-    width: 32px;
-    height: 24px;
-    line-height: 24px;
-    text-align: center;
-    margin-right: 4px;
-    border: 2px solid transparent;
-    cursor: pointer;
-}
-
-.aorp-template-swatch.selected {
-    border-color: #007cba;
-}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -156,16 +156,4 @@ jQuery(document).ready(function($){
         updateIconFields();
     }
 
-    if($('#aorp_template_preview').length){
-        function updateTemplatePreview(){
-            var val = $('#aorp_dark_template').val();
-            $('.aorp-template-swatch').removeClass('selected');
-            $('.aorp-template-swatch[data-template='+val+']').addClass('selected');
-        }
-        $('#aorp_dark_template').on('change', updateTemplatePreview);
-        $('#aorp_template_preview').on('click', '.aorp-template-swatch', function(){
-            $('#aorp_dark_template').val($(this).data('template')).trigger('change');
-        });
-        updateTemplatePreview();
-    }
 });

--- a/assets/script.js
+++ b/assets/script.js
@@ -35,15 +35,13 @@ jQuery(document).ready(function($){
         $('#aorp-toggle').html(aorp_ajax.icon_light);
     }
 
-    var templateClass = 'aorp-template-' + (aorp_ajax.template || 1);
-
     function setDark(active){
         if(active){
-            $('body').addClass('aorp-dark ' + templateClass);
+            $('body').addClass('aorp-dark');
             $('#aorp-toggle').html(aorp_ajax.icon_dark);
             localStorage.setItem('aorp-dark-mode','on');
         }else{
-            $('body').removeClass('aorp-dark ' + templateClass);
+            $('body').removeClass('aorp-dark');
             $('#aorp-toggle').html(aorp_ajax.icon_light);
             localStorage.setItem('aorp-dark-mode','off');
         }

--- a/assets/style.css
+++ b/assets/style.css
@@ -22,26 +22,6 @@
 #aorp-search{width:100%;padding:0.5em;margin:0}
 body.aorp-dark{background:#222;color:#eee}
 body.aorp-dark .aorp-category{background:#333;color:#fff}
-body.aorp-dark.aorp-template-1{background:#222;color:#eee}
-body.aorp-dark.aorp-template-1 .aorp-category{background:#333;color:#fff}
-body.aorp-dark.aorp-template-2{background:#111;color:#ddd}
-body.aorp-dark.aorp-template-2 .aorp-category{background:#222;color:#eee}
-body.aorp-dark.aorp-template-3{background:#000;color:#fff}
-body.aorp-dark.aorp-template-3 .aorp-category{background:#444;color:#fff}
-body.aorp-dark.aorp-template-4{background:#2b2b2b;color:#f5f5f5}
-body.aorp-dark.aorp-template-4 .aorp-category{background:#3b3b3b;color:#fff}
-body.aorp-dark.aorp-template-5{background:#1a1a1a;color:#e0e0e0}
-body.aorp-dark.aorp-template-5 .aorp-category{background:#444;color:#fff}
-body.aorp-dark.aorp-template-6{background:#121212;color:#e8e8e8}
-body.aorp-dark.aorp-template-6 .aorp-category{background:#242424;color:#fff}
-body.aorp-dark.aorp-template-7{background:#191919;color:#f0f0f0}
-body.aorp-dark.aorp-template-7 .aorp-category{background:#333;color:#fff}
-body.aorp-dark.aorp-template-8{background:#202020;color:#fafafa}
-body.aorp-dark.aorp-template-8 .aorp-category{background:#444;color:#fff}
-body.aorp-dark.aorp-template-9{background:#000;color:#e6e6e6}
-body.aorp-dark.aorp-template-9 .aorp-category{background:#333;color:#fff}
-body.aorp-dark.aorp-template-10{background:#141414;color:#e5e5e5}
-body.aorp-dark.aorp-template-10 .aorp-category{background:#2a2a2a;color:#fff}
 #aorp-toggle{position:fixed;bottom:20px;right:20px;cursor:pointer;padding:0.5em;background:#000;color:#fff;border-radius:3px;z-index:9999}
 .aorp-selected{margin-bottom:.5em}
 .aorp-ing-chip{background:#eee;padding:2px 5px;margin-right:4px;display:inline-block;border-radius:3px}


### PR DESCRIPTION
## Summary
- delete Dark Mode template options in README
- remove Dark Mode template selection from admin UI
- strip template CSS classes and JS logic
- drop template option from PHP plugin code

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855a08032908329a7b1d14306f38e16