### PR TITLE
Add import templates with download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,15 @@ Zunächst wählst du ein passendes Icon-Set oder lädst eigene Symbole hoch. Ans
 
 Kostenlose Icons findest du zum Beispiel auf [flaticon.com](https://www.flaticon.com).
 
+
+### Mustervorlagen für den Import
+
+Im Bereich **Import/Export** stehen jetzt Beispieldateien zur Verfügung.
+Sie helfen dir dabei, CSV-, JSON- oder YAML-Dateien korrekt zu strukturieren.
+Du findest die Vorlagen direkt auf der Import/Export-Seite:
+
+- `import-template.csv`
+- `import-template.json`
+- `import-template.yaml`
+
+Lade die gewünschte Datei herunter, trage deine Daten ein und importiere sie anschließend wieder über das Formular.

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -615,6 +615,12 @@ class AIO_Restaurant_Plugin {
         ?>
         <div class="wrap">
             <h1>Import/Export</h1>
+            <h2>Mustervorlagen</h2>
+            <ul>
+                <li><a href="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'samples/import-template.csv' ); ?>">CSV Vorlage</a></li>
+                <li><a href="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'samples/import-template.json' ); ?>">JSON Vorlage</a></li>
+                <li><a href="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'samples/import-template.yaml' ); ?>">YAML Vorlage</a></li>
+            </ul>
             <form method="post" action="<?php echo admin_url( 'admin-post.php' ); ?>" enctype="multipart/form-data">
                 <input type="hidden" name="action" value="aorp_import_csv" />
                 <select name="import_format">

--- a/samples/import-template.csv
+++ b/samples/import-template.csv
@@ -1,0 +1,2 @@
+Nummer,Titel,Beschreibung,Preis,Kategorie,Inhaltsstoffe,Bild-ID
+1,Margherita,Tomate und Mozzarella,7.90,pizza,"A,B",0

--- a/samples/import-template.json
+++ b/samples/import-template.json
@@ -1,0 +1,28 @@
+{
+  "categories": [
+    {
+      "code": "pizza",
+      "name": "Pizzen",
+      "bg": "#f0f0f0",
+      "color": "#000000",
+      "font_size": "",
+      "width": "",
+      "height": ""
+    }
+  ],
+  "ingredients": [
+    {"code": "A", "name": "Gluten"},
+    {"code": "B", "name": "Milch"}
+  ],
+  "items": [
+    {
+      "number": "1",
+      "title": "Margherita",
+      "description": "Tomate, Mozzarella",
+      "price": "7.90",
+      "category": "pizza",
+      "ingredients": "A,B",
+      "image_id": ""
+    }
+  ]
+}

--- a/samples/import-template.yaml
+++ b/samples/import-template.yaml
@@ -1,0 +1,21 @@
+categories:
+  - code: pizza
+    name: Pizzen
+    bg: "#f0f0f0"
+    color: "#000000"
+    font_size: ''
+    width: ''
+    height: ''
+ingredients:
+  - code: A
+    name: Gluten
+  - code: B
+    name: Milch
+items:
+  - number: "1"
+    title: Margherita
+    description: Tomate, Mozzarella
+    price: "7.90"
+    category: pizza
+    ingredients: "A,B"
+    image_id: ''


### PR DESCRIPTION
## Summary
- add CSV, JSON and YAML templates for import
- link templates on the Import/Export admin page
- document templates in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855af4afe8c8329983992ad4d44e98d