### PR TITLE
Remove category codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 3. Import/Export & Historie
 4. Widgets für Speisekarte und Lightswitcher
 5. Einfache Verwaltung aller Daten auf einer Seite inklusive Bearbeiten und Löschen von Speisen sowie Filterfunktion
-6. Kategorien besitzen Code und Bezeichnung und lassen sich filtern und bearbeiten
+6. Kategorien besitzen eine Bezeichnung und lassen sich filtern und bearbeiten
 7. Import/Export berücksichtigt Kategorien, Inhaltsstoffe und weitere Einstellungen
 8. Spaltenanzahl der Speisekarte (1–3) über Einstellungen wählbar
 9. Schriftgrößen für Nummer, Titel, Beschreibung und Preis über den Einstellungen-Bereich Darstellung per Dropdown anpassbar

--- a/samples/import-template.csv
+++ b/samples/import-template.csv
@@ -1,2 +1,2 @@
 Nummer,Titel,Beschreibung,Preis,Kategorie,Inhaltsstoffe,Bild-ID
-1,Margherita,Tomate und Mozzarella,7.90,pizza,"A,B",0
+1,Margherita,Tomate und Mozzarella,7.90,Pizzen,"A,B",0

--- a/samples/import-template.json
+++ b/samples/import-template.json
@@ -1,7 +1,6 @@
 {
   "categories": [
     {
-      "code": "pizza",
       "name": "Pizzen",
       "bg": "#f0f0f0",
       "color": "#000000",
@@ -20,7 +19,7 @@
       "title": "Margherita",
       "description": "Tomate, Mozzarella",
       "price": "7.90",
-      "category": "pizza",
+      "category": "Pizzen",
       "ingredients": "A,B",
       "image_id": ""
     }

--- a/samples/import-template.yaml
+++ b/samples/import-template.yaml
@@ -1,6 +1,5 @@
 categories:
-  - code: pizza
-    name: Pizzen
+  - name: Pizzen
     bg: "#f0f0f0"
     color: "#000000"
     font_size: ''
@@ -16,6 +15,6 @@ items:
     title: Margherita
     description: Tomate, Mozzarella
     price: "7.90"
-    category: pizza
+    category: Pizzen
     ingredients: "A,B"
     image_id: ''


### PR DESCRIPTION
## Summary
- categories no longer store or use a separate code
- adjust admin forms and import/export logic
- update sample import files to reference category names
- tweak README wording

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l includes/widgets.php`
- `php -r 'json_decode(file_get_contents("samples/import-template.json"),true);echo json_last_error_msg();'`

------
https://chatgpt.com/codex/tasks/task_e_6855b3bacd74832995fb8796cf0a6513