### PR TITLE
Add button to collapse all menu categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.1.8
+Version: 1.1.9
 Autor: Dein Name
 
 ## Übersicht

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: All-In-One WordPress Restaurant Plugin
 Description: Umfangreiches Speisekarten-Plugin mit Dark‑Mode, Suchfunktion und Import/Export.
-Version: 1.1.8
+Version: 1.1.9
 Author: stb-srv
 */
 
@@ -469,7 +469,7 @@ class AIO_Restaurant_Plugin {
 
         ob_start();
         echo '<p class="aorp-note">🔽 Klicke auf eine Kategorie, um die Speisen einzublenden.</p>';
-        echo '<div class="aorp-search-wrap columns-' . $columns . '"><input type="text" id="aorp-search" placeholder="Suche nach Speisen …" /></div>';
+        echo '<div class="aorp-search-wrap columns-' . $columns . '"><input type="text" id="aorp-search" placeholder="Suche nach Speisen …" /><button type="button" id="aorp-close-cats" class="aorp-close-cats">Alle Kategorien schließen</button></div>';
 
         echo '<div class="aorp-menu columns-' . $columns . '">';
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -29,6 +29,10 @@ jQuery(document).ready(function($){
         });
     });
 
+    $('#aorp-close-cats').on('click', function(){
+        $('.aorp-items').slideUp();
+    });
+
     if($('#aorp-toggle').length===0){
         $('body').append('<div id="aorp-toggle" aria-label="Dark Mode umschalten" role="button" tabindex="0">'+aorp_ajax.icon_light+'</div>');
     } else {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,7 +1,8 @@
 .aorp-menu{margin:1em 0}
 .aorp-note{margin-bottom:0.5em;font-weight:bold}
-.aorp-search-wrap{text-align:center;margin-bottom:1em}
-.aorp-search-wrap input{width:100%;padding:0.5em}
+.aorp-search-wrap{display:flex;align-items:center;gap:0.5em;text-align:center;margin-bottom:1em}
+.aorp-search-wrap input{flex:1;padding:0.5em}
+.aorp-close-cats{padding:0.5em}
 .aorp-search-wrap.columns-2{width:48%;margin-left:auto;margin-right:auto}
 .aorp-search-wrap.columns-3{width:31%;margin-left:auto;margin-right:auto}
 .aorp-category{cursor:pointer;background:#eee;padding:0.5em;margin-bottom:0.2em;display:flex;align-items:center;min-height:40px;box-sizing:border-box}


### PR DESCRIPTION
## Summary
- bump plugin version to 1.1.9
- add a button for closing all categories
- style search area to fit new button
- support closing categories via JavaScript

## Testing
- `node --check assets/script.js`
- `php -l all-in-one-restaurant-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d216d29483299e36365cf63c6af0