### PR TITLE
Fix YAML parser to include inline item values

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -1216,11 +1216,16 @@ class AIO_Restaurant_Plugin {
                 }
                 $section       = rtrim( $line, ':' );
                 $data[ $section ] = array();
-            } elseif ( preg_match( '/^\s*-/', $line ) ) {
+            } elseif ( preg_match( '/^\s*-\s*(.*)/', $line, $m ) ) {
                 if ( $current && $section ) {
                     $data[ $section ][] = $current;
                 }
                 $current = array();
+                $inline  = trim( $m[1] );
+                if ( '' !== $inline ) {
+                    list( $k, $v ) = array_map( 'trim', explode( ':', $inline, 2 ) );
+                    $current[ $k ] = str_replace( '\\n', "\n", $v );
+                }
             } else {
                 list( $k, $v ) = array_map( 'trim', explode( ':', $line, 2 ) );
                 $current[ $k ] = str_replace( '\\n', "\n", $v );


### PR DESCRIPTION
## Summary
- handle YAML list items that include data on the same line

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856996848a08329842d02c0c514fabb