### PR TITLE
Fix YAML import quoting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Du findest die Vorlagen direkt auf der Import/Export-Seite:
 - `import-template.yaml`
 
 Lade die gewünschte Datei herunter, trage deine Daten ein und importiere sie anschließend wieder über das Formular.
+Beim YAML-Format können Nummern und Preise ohne Anführungszeichen angegeben werden. Eventuell vorhandene Anführungszeichen werden beim Import automatisch entfernt.

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -1224,11 +1224,15 @@ class AIO_Restaurant_Plugin {
                 $inline  = trim( $m[1] );
                 if ( '' !== $inline ) {
                     list( $k, $v ) = array_map( 'trim', explode( ':', $inline, 2 ) );
-                    $current[ $k ] = str_replace( '\\n', "\n", $v );
+                    $v = str_replace( '\\n', "\n", $v );
+                    $v = $this->trim_quotes( $v );
+                    $current[ $k ] = $v;
                 }
             } else {
                 list( $k, $v ) = array_map( 'trim', explode( ':', $line, 2 ) );
-                $current[ $k ] = str_replace( '\\n', "\n", $v );
+                $v = str_replace( '\\n', "\n", $v );
+                $v = $this->trim_quotes( $v );
+                $current[ $k ] = $v;
             }
         }
 
@@ -1237,6 +1241,15 @@ class AIO_Restaurant_Plugin {
         }
 
         return $data;
+    }
+
+    private function trim_quotes( $value ) {
+        if ( is_string( $value ) && strlen( $value ) > 1 ) {
+            if ( ( $value[0] === '"' && substr( $value, -1 ) === '"' ) || ( $value[0] === "'" && substr( $value, -1 ) === "'" ) ) {
+                return substr( $value, 1, -1 );
+            }
+        }
+        return $value;
     }
 
     private $ingredient_lookup = null;


### PR DESCRIPTION
## Summary
- strip surrounding quotes when importing YAML
- document quoting behavior in README

## Testing
- `php -l all-in-one-restaurant-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68569c92ede483299c74ad2a4fbd812b