### PR TITLE
Add WP Grid Menu Overlay module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 
 - [speisekarte] – Zeigt die Speisekarte an
 - [restaurant_lightswitcher] – Dark Mode Switcher
+- [wp_grid_menu_overlay] – Overlay mit Öffnungszeiten, Kontakt & mehr
 Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verwendet werden.
 
 ## Dark‑Mode Icons
@@ -76,3 +77,22 @@ Du findest die Vorlagen direkt auf der Import/Export-Seite:
 
 Lade die gewünschte Datei herunter, trage deine Daten ein und importiere sie anschließend wieder über das Formular.
 Beim YAML-Format können Nummern und Preise ohne Anführungszeichen angegeben werden. Eventuell vorhandene Anführungszeichen werden beim Import automatisch entfernt.
+
+## WP Grid Menu Overlay
+
+Dieses Modul zeigt Öffnungszeiten und weitere Infos im Kachel‑Layout an.
+Beispielwerte werden automatisch verwendet, wenn keine eigenen Angaben
+hinterlegt sind:
+
+```
+Willkommens‑Titel: "Willkommen"
+Öffnungszeiten: "Montag bis Freitag: 9–18 Uhr"
+About‑Text: "Kurze Beschreibung des Restaurants."
+Kontakt‑Adresse: "123 Musterstraße, 98765 Stadt"
+Telefon: "01234/56789"
+E‑Mail: "mail@example.com"
+Formular‑Shortcode: "[contact-form-7 id=\"1\"]"
+Karten‑Embed: "<iframe src=...></iframe>"
+```
+
+Nutze den Shortcode `[wp_grid_menu_overlay]`, um das Grid auf einer Seite einzubinden.

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -1545,7 +1545,11 @@ class AIO_Restaurant_Plugin {
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/widgets.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-kontaktblockpro.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-grid-menu-overlay.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-grid-menu-overlay-admin.php';
 
+WP_Grid_Menu_Overlay::instance();
+WP_Grid_Menu_Overlay_Admin::instance();
 new AORP_KontaktblockPro();
 
 new AIO_Restaurant_Plugin();

--- a/assets/css/wp-grid-menu-overlay.css
+++ b/assets/css/wp-grid-menu-overlay.css
@@ -1,0 +1,33 @@
+.wpgmo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+@media (max-width: 600px) {
+  .wpgmo-grid { grid-template-columns: 1fr; }
+}
+
+.wpgmo-item {
+  background: var(--bg-color, #fff);
+  color: var(--text-color, #000);
+  padding: 1rem;
+  border-radius: 8px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.wpgmo-item h2 {
+  margin-top: 0;
+  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+}
+
+.wpgmo-item p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
+body.dark .wpgmo-item {
+  background: var(--dark-bg, #333);
+  color: var(--dark-text, #fff);
+}

--- a/includes/class-wp-grid-menu-overlay-admin.php
+++ b/includes/class-wp-grid-menu-overlay-admin.php
@@ -1,0 +1,133 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Grid_Menu_Overlay_Admin {
+
+    private static $instance = null;
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'admin_menu', [ $this, 'admin_menu' ] );
+        add_action( 'admin_init', [ $this, 'admin_init' ] );
+    }
+
+    public function admin_menu() {
+        add_menu_page(
+            __( 'WP Grid Menu Overlay', 'wpgmo' ),
+            __( 'WP Grid Menu', 'wpgmo' ),
+            'manage_options',
+            'wpgmo_settings',
+            [ $this, 'render_settings_page' ],
+            'dashicons-screenoptions',
+            80
+        );
+    }
+
+    public function admin_init() {
+        register_setting( 'wpgmo_settings_group', 'wpgmo_settings', [ $this, 'sanitize_settings' ] );
+
+        add_settings_section( 'wpgmo_main', __( 'Allgemeine Einstellungen', 'wpgmo' ), null, 'wpgmo_settings' );
+
+        add_settings_field( 'wpgmo_welcome_title', __( 'Willkommens-Titel', 'wpgmo' ), [ $this, 'field_welcome_title' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_opening_hours', __( 'Öffnungszeiten', 'wpgmo' ), [ $this, 'field_opening_hours' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_about_text', __( 'Über uns Text', 'wpgmo' ), [ $this, 'field_about_text' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_contact_address', __( 'Kontakt-Adresse', 'wpgmo' ), [ $this, 'field_contact_address' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_contact_phone', __( 'Telefon', 'wpgmo' ), [ $this, 'field_contact_phone' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_contact_email', __( 'E-Mail', 'wpgmo' ), [ $this, 'field_contact_email' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_form_shortcode', __( 'Formular Shortcode', 'wpgmo' ), [ $this, 'field_form_shortcode' ], 'wpgmo_settings', 'wpgmo_main' );
+        add_settings_field( 'wpgmo_map_embed', __( 'Karte einbetten', 'wpgmo' ), [ $this, 'field_map_embed' ], 'wpgmo_settings', 'wpgmo_main' );
+    }
+
+    public function render_settings_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'WP Grid Menu Overlay', 'wpgmo' ) . '</h1>';
+        ?>
+        <form method="post" action="options.php">
+            <?php settings_fields( 'wpgmo_settings_group' ); ?>
+            <?php do_settings_sections( 'wpgmo_settings' ); ?>
+            <?php submit_button(); ?>
+        </form>
+        <?php
+        echo '</div>';
+    }
+
+    public function field_welcome_title() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_attr( $opts['welcome_title'] ?? '' );
+        echo '<input type="text" name="wpgmo_settings[welcome_title]" value="' . $value . '" class="regular-text" />';
+    }
+
+    public function field_opening_hours() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_attr( $opts['opening_hours'] ?? '' );
+        echo '<input type="text" name="wpgmo_settings[opening_hours]" value="' . $value . '" class="regular-text" />';
+    }
+
+    public function field_about_text() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_textarea( $opts['about_text'] ?? '' );
+        echo '<textarea name="wpgmo_settings[about_text]" rows="5" class="large-text">' . $value . '</textarea>';
+    }
+
+    public function field_contact_address() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_textarea( $opts['contact_address'] ?? '' );
+        echo '<textarea name="wpgmo_settings[contact_address]" rows="3" class="large-text">' . $value . '</textarea>';
+    }
+
+    public function field_contact_phone() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_attr( $opts['contact_phone'] ?? '' );
+        echo '<input type="text" name="wpgmo_settings[contact_phone]" value="' . $value . '" class="regular-text" />';
+    }
+
+    public function field_contact_email() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_attr( $opts['contact_email'] ?? '' );
+        echo '<input type="email" name="wpgmo_settings[contact_email]" value="' . $value . '" class="regular-text" />';
+    }
+
+    public function field_form_shortcode() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_attr( $opts['form_shortcode'] ?? '' );
+        echo '<input type="text" name="wpgmo_settings[form_shortcode]" value="' . $value . '" class="regular-text" />';
+    }
+
+    public function field_map_embed() {
+        $opts  = get_option( 'wpgmo_settings', [] );
+        $value = esc_textarea( $opts['map_embed'] ?? '' );
+        echo '<textarea name="wpgmo_settings[map_embed]" rows="5" class="large-text">' . $value . '</textarea>';
+    }
+
+    public function sanitize_settings( $input ) {
+        $defaults = [
+            'welcome_title'   => 'Willkommen',
+            'opening_hours'   => '',
+            'about_text'      => '',
+            'contact_address' => '',
+            'contact_phone'   => '',
+            'contact_email'   => '',
+            'form_shortcode'  => '',
+            'map_embed'       => '',
+        ];
+
+        $output                     = [];
+        $output['welcome_title']    = sanitize_text_field( $input['welcome_title'] ?? $defaults['welcome_title'] );
+        $output['opening_hours']    = sanitize_text_field( $input['opening_hours'] ?? $defaults['opening_hours'] );
+        $output['about_text']       = sanitize_textarea_field( $input['about_text'] ?? $defaults['about_text'] );
+        $output['contact_address']  = sanitize_textarea_field( $input['contact_address'] ?? $defaults['contact_address'] );
+        $output['contact_phone']    = sanitize_text_field( $input['contact_phone'] ?? $defaults['contact_phone'] );
+        $output['contact_email']    = sanitize_email( $input['contact_email'] ?? $defaults['contact_email'] );
+        $output['form_shortcode']   = wp_kses_post( $input['form_shortcode'] ?? $defaults['form_shortcode'] );
+        $output['map_embed']        = wp_kses_post( $input['map_embed'] ?? $defaults['map_embed'] );
+
+        return $output;
+    }
+}

--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -1,0 +1,99 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Grid_Menu_Overlay {
+
+    private static $instance = null;
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', [ $this, 'register_shortcode' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'register_assets' ] );
+    }
+
+    public function register_assets() {
+        if ( is_admin() ) {
+            return;
+        }
+        wp_register_style( 'wpgmo-styles', plugin_dir_url( __FILE__ ) . '../assets/css/wp-grid-menu-overlay.css', [], '1.0' );
+    }
+
+    public function register_shortcode() {
+        add_shortcode( 'wp_grid_menu_overlay', [ $this, 'render_shortcode' ] );
+    }
+
+    private function enqueue_assets() {
+        if ( is_admin() ) {
+            return;
+        }
+        wp_enqueue_style( 'wpgmo-styles' );
+    }
+
+    public function render_shortcode( $atts ) {
+        $this->enqueue_assets();
+
+        $opts    = get_option( 'wpgmo_settings', [] );
+        $welcome = sanitize_text_field( $opts['welcome_title'] ?? __( 'Willkommen', 'wpgmo' ) );
+        $hours   = sanitize_text_field( $opts['opening_hours'] ?? '' );
+        $about   = sanitize_textarea_field( $opts['about_text'] ?? '' );
+        $address = sanitize_textarea_field( $opts['contact_address'] ?? '' );
+        $phone   = sanitize_text_field( $opts['contact_phone'] ?? '' );
+        $email   = sanitize_email( $opts['contact_email'] ?? '' );
+        $form    = wp_kses_post( $opts['form_shortcode'] ?? '' );
+        $map     = wp_kses_post( $opts['map_embed'] ?? '' );
+
+        ob_start();
+        ?>
+        <div class="wpgmo-grid">
+            <div class="wpgmo-item wpgmo-welcome">
+                <h2><?php echo esc_html( $welcome ); ?></h2>
+            </div>
+            <?php if ( $hours ) : ?>
+            <div class="wpgmo-item wpgmo-openings">
+                <h2><?php _e( 'Öffnungszeiten', 'wpgmo' ); ?></h2>
+                <p><?php echo esc_html( $hours ); ?></p>
+            </div>
+            <?php endif; ?>
+            <?php if ( $about ) : ?>
+            <div class="wpgmo-item wpgmo-about">
+                <h2><?php _e( 'Über uns', 'wpgmo' ); ?></h2>
+                <p><?php echo esc_html( $about ); ?></p>
+            </div>
+            <?php endif; ?>
+            <?php if ( $address || $phone || $email ) : ?>
+            <div class="wpgmo-item wpgmo-contact">
+                <h2><?php _e( 'Kontakt', 'wpgmo' ); ?></h2>
+                <?php if ( $address ) : ?>
+                    <p><?php echo nl2br( esc_html( $address ) ); ?></p>
+                <?php endif; ?>
+                <?php if ( $phone ) : ?>
+                    <p><?php echo esc_html( $phone ); ?></p>
+                <?php endif; ?>
+                <?php if ( $email ) : ?>
+                    <p><a href="mailto:<?php echo antispambot( esc_attr( $email ) ); ?>"><?php echo antispambot( esc_html( $email ) ); ?></a></p>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
+            <?php if ( $form ) : ?>
+            <div class="wpgmo-item wpgmo-form">
+                <?php echo do_shortcode( $form ); ?>
+            </div>
+            <?php endif; ?>
+            <?php if ( $map ) : ?>
+            <div class="wpgmo-item wpgmo-map">
+                <?php echo $map; ?>
+            </div>
+            <?php endif; ?>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WP_Grid_Menu_Overlay` for frontend output
- add `WP_Grid_Menu_Overlay_Admin` with settings page
- load both classes from main plugin
- provide CSS for grid overlay
- document new shortcode and defaults

## Testing
- `php -l includes/class-wp-grid-menu-overlay.php` *(fails: `php` not found)*


------
https://chatgpt.com/codex/tasks/task_e_685bcdfa97b0832996d4b0e301ab55af