### PR TITLE
Add shortcode manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.2.1
+Version: 1.3.0
 Autor: Dein Name
 
 ## Übersicht
@@ -17,6 +17,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 8. Spaltenanzahl der Speisekarte (1–3) über Einstellungen wählbar
 9. Schriftgrößen für Nummer, Titel, Beschreibung und Preis über den Einstellungen-Bereich Darstellung per Dropdown anpassbar
 10. Preise werden stets mit dem Euro-Zeichen ("€") angezeigt
+11. Eigener Shortcode-Generator für individuelle Menüs
 
 ## Installation
 
@@ -29,6 +30,7 @@ Dieses Plugin bietet alles, was Restaurant-Personal ohne IT-Kenntnisse benötigt
 
 - [speisekarte] – Zeigt die Speisekarte an
 - [restaurant_lightswitcher] – Dark Mode Switcher
+- [aorp_menu id="ID"] – Gibt eine gespeicherte Speisekarte aus
 - [wp_grid_menu_overlay] – Overlay mit Öffnungszeiten, Kontakt & mehr
 Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verwendet werden.
 


### PR DESCRIPTION
## Summary
- add shortcode manager for custom menus
- expose `[aorp_menu]` shortcode
- document new feature in README

## Testing
- `php -l all-in-one-restaurant-plugin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd0b13a788329b7b407bb26b5392e