### PR TITLE
Add grid overlay builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Beim YAML-Format können Nummern und Preise ohne Anführungszeichen angegeben we
 
 Dieses Modul zeigt Öffnungszeiten und weitere Infos im Kachel‑Layout an.
 Beispielwerte werden automatisch verwendet, wenn keine eigenen Angaben
-hinterlegt sind:
+hinterlegt sind. Über den Shortcode‑Generator lässt sich zudem ein individueller
+Aufbau des Grids definieren. Jeder Eintrag kann als "kleine" oder "große" Kachel
+angelegt und beliebig sortiert werden:
 
 ```
 Willkommens‑Titel: "Willkommen"
@@ -98,3 +100,4 @@ Karten‑Embed: "<iframe src=...></iframe>"
 ```
 
 Nutze den Shortcode `[wp_grid_menu_overlay]` oder `[wp_grid_menu_overlay id="ID"]`, um das Grid auf einer Seite einzubinden.
+Die Verwaltung eigener Overlays befindet sich unter **WP Grid Menu → Shortcodes**.

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -74,6 +74,7 @@ jQuery(document).ready(function($){
     });
 
     var aorp_frame;
+    var wpgmoLayout = {small:'Klein', large:'Groß'};
     $(document).on('click', '.aorp-image-upload', function(e){
         e.preventDefault();
         var button = $(this);
@@ -154,6 +155,50 @@ jQuery(document).ready(function($){
         }
         $('#aorp_icon_set').on('change',updateIconFields);
         updateIconFields();
+    }
+
+    if($('#wpgmo-layout-table').length){
+        function updateLayout(){
+            var layout = [];
+            $('#wpgmo-layout-table tbody tr').each(function(){
+                var type = $(this).find('.wpgmo-type').val();
+                var size = $(this).find('.wpgmo-size').val();
+                if(type){
+                    layout.push({type:type, size:size});
+                }
+            });
+            $('#wpgmo_layout').val(JSON.stringify(layout));
+        }
+
+        $('#wpgmo_add_row').on('click', function(e){
+            e.preventDefault();
+            var row = $('<tr>\
+                <td><select class="wpgmo-type">'+$('#wpgmo_types_options').html()+'</select></td>\
+                <td><select class="wpgmo-size"><option value="small">'+wpgmoLayout.small+'</option><option value="large">'+wpgmoLayout.large+'</option></select></td>\
+                <td><button class="button wpgmo-remove-row">×</button></td></tr>');
+            $('#wpgmo-layout-table tbody').append(row);
+        });
+
+        $(document).on('click','.wpgmo-remove-row',function(e){
+            e.preventDefault();
+            $(this).closest('tr').remove();
+            updateLayout();
+        });
+
+        $(document).on('change','#wpgmo-layout-table select', updateLayout);
+
+        try {
+            var data = JSON.parse($('#wpgmo_layout').val());
+            if(Array.isArray(data)){
+                data.forEach(function(cell){
+                    $('#wpgmo_add_row').trigger('click');
+                    var row = $('#wpgmo-layout-table tbody tr:last');
+                    row.find('.wpgmo-type').val(cell.type);
+                    row.find('.wpgmo-size').val(cell.size);
+                });
+            }
+        } catch(e){}
+        updateLayout();
     }
 
 });

--- a/assets/css/wp-grid-menu-overlay.css
+++ b/assets/css/wp-grid-menu-overlay.css
@@ -5,18 +5,23 @@
 }
 @media (max-width: 600px) {
   .wpgmo-grid { grid-template-columns: 1fr; }
+  .wpgmo-item.size-large { grid-column: span 1; }
 }
 
-.wpgmo-item {
-  background: var(--bg-color, #fff);
-  color: var(--text-color, #000);
-  padding: 1rem;
-  border-radius: 8px;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-}
+  .wpgmo-item {
+    background: var(--bg-color, #fff);
+    color: var(--text-color, #000);
+    padding: 1rem;
+    border-radius: 8px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+
+  .wpgmo-item.size-large {
+    grid-column: span 2;
+  }
 
 .wpgmo-item h2 {
   margin-top: 0;

--- a/includes/class-wp-grid-menu-overlay-admin.php
+++ b/includes/class-wp-grid-menu-overlay-admin.php
@@ -209,6 +209,27 @@ class WP_Grid_Menu_Overlay_Admin {
                         <th scope="row"><label for="wpgmo_sc_map">Karte einbetten</label></th>
                         <td><textarea id="wpgmo_sc_map" name="map_embed" rows="3" class="large-text"><?php echo esc_textarea( $current['map_embed'] ?? '' ); ?></textarea></td>
                     </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Grid Layout', 'wpgmo' ); ?></th>
+                        <td>
+                            <table class="widefat" id="wpgmo-layout-table">
+                                <thead>
+                                <tr><th><?php esc_html_e( 'Element', 'wpgmo' ); ?></th><th><?php esc_html_e( 'Größe', 'wpgmo' ); ?></th><th></th></tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                            <select id="wpgmo_types_options" style="display:none">
+                                <option value="welcome"><?php esc_html_e( 'Willkommen', 'wpgmo' ); ?></option>
+                                <option value="openings"><?php esc_html_e( 'Öffnungszeiten', 'wpgmo' ); ?></option>
+                                <option value="about"><?php esc_html_e( 'Über uns', 'wpgmo' ); ?></option>
+                                <option value="contact"><?php esc_html_e( 'Kontakt', 'wpgmo' ); ?></option>
+                                <option value="form"><?php esc_html_e( 'Formular', 'wpgmo' ); ?></option>
+                                <option value="map"><?php esc_html_e( 'Karte', 'wpgmo' ); ?></option>
+                            </select>
+                            <input type="hidden" id="wpgmo_layout" name="grid_layout" value="<?php echo esc_attr( $current['grid_layout'] ?? '' ); ?>" />
+                            <p><button type="button" class="button" id="wpgmo_add_row"><?php esc_html_e( 'Element hinzufügen', 'wpgmo' ); ?></button></p>
+                        </td>
+                    </tr>
                 </table>
                 <?php submit_button( $current ? esc_html__( 'Aktualisieren', 'wpgmo' ) : esc_html__( 'Anlegen', 'wpgmo' ) ); ?>
             </form>
@@ -234,7 +255,26 @@ class WP_Grid_Menu_Overlay_Admin {
             'contact_email'  => sanitize_email( $_POST['contact_email'] ?? '' ),
             'form_shortcode' => wp_kses_post( $_POST['form_shortcode'] ?? '' ),
             'map_embed'      => wp_kses_post( $_POST['map_embed'] ?? '' ),
+            'grid_layout'    => '',
         ];
+        if ( isset( $_POST['grid_layout'] ) ) {
+            $raw    = wp_unslash( $_POST['grid_layout'] );
+            $layout = json_decode( $raw, true );
+            $allowed = [ 'welcome', 'openings', 'about', 'contact', 'form', 'map' ];
+            $clean  = [];
+            if ( is_array( $layout ) ) {
+                foreach ( $layout as $cell ) {
+                    if ( empty( $cell['type'] ) || ! in_array( $cell['type'], $allowed, true ) ) {
+                        continue;
+                    }
+                    $clean[] = [
+                        'type' => $cell['type'],
+                        'size' => ( isset( $cell['size'] ) && 'large' === $cell['size'] ) ? 'large' : 'small',
+                    ];
+                }
+            }
+            $entry['grid_layout'] = wp_json_encode( $clean );
+        }
         if ( $id ) {
             foreach ( $shortcodes as &$sc ) {
                 if ( $sc['id'] == $id ) {
@@ -260,6 +300,7 @@ class WP_Grid_Menu_Overlay_Admin {
             'contact_email'   => '',
             'form_shortcode'  => '',
             'map_embed'       => '',
+            'grid_layout'     => '',
         ];
 
         $output                     = [];
@@ -271,6 +312,7 @@ class WP_Grid_Menu_Overlay_Admin {
         $output['contact_email']    = sanitize_email( $input['contact_email'] ?? $defaults['contact_email'] );
         $output['form_shortcode']   = wp_kses_post( $input['form_shortcode'] ?? $defaults['form_shortcode'] );
         $output['map_embed']        = wp_kses_post( $input['map_embed'] ?? $defaults['map_embed'] );
+        $output['grid_layout']      = wp_kses_post( $input['grid_layout'] ?? $defaults['grid_layout'] );
 
         return $output;
     }

--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -62,49 +62,94 @@ class WP_Grid_Menu_Overlay {
         $email   = sanitize_email( $opts['contact_email'] ?? '' );
         $form    = wp_kses_post( $opts['form_shortcode'] ?? '' );
         $map     = wp_kses_post( $opts['map_embed'] ?? '' );
+        $layout  = [];
+        if ( ! empty( $opts['grid_layout'] ) ) {
+            $layout = json_decode( $opts['grid_layout'], true );
+        }
+        if ( ! is_array( $layout ) || empty( $layout ) ) {
+            $layout = [
+                [ 'type' => 'welcome',  'size' => 'small' ],
+                [ 'type' => 'openings', 'size' => 'small' ],
+                [ 'type' => 'about',    'size' => 'small' ],
+                [ 'type' => 'contact',  'size' => 'small' ],
+                [ 'type' => 'form',     'size' => 'small' ],
+                [ 'type' => 'map',      'size' => 'small' ],
+            ];
+        }
 
         ob_start();
         ?>
         <div class="wpgmo-grid">
-            <div class="wpgmo-item wpgmo-welcome">
-                <h2><?php echo esc_html( $welcome ); ?></h2>
-            </div>
-            <?php if ( $hours ) : ?>
-            <div class="wpgmo-item wpgmo-openings">
-                <h2><?php _e( 'Öffnungszeiten', 'wpgmo' ); ?></h2>
-                <p><?php echo esc_html( $hours ); ?></p>
-            </div>
-            <?php endif; ?>
-            <?php if ( $about ) : ?>
-            <div class="wpgmo-item wpgmo-about">
-                <h2><?php _e( 'Über uns', 'wpgmo' ); ?></h2>
-                <p><?php echo esc_html( $about ); ?></p>
-            </div>
-            <?php endif; ?>
-            <?php if ( $address || $phone || $email ) : ?>
-            <div class="wpgmo-item wpgmo-contact">
-                <h2><?php _e( 'Kontakt', 'wpgmo' ); ?></h2>
-                <?php if ( $address ) : ?>
-                    <p><?php echo nl2br( esc_html( $address ) ); ?></p>
-                <?php endif; ?>
-                <?php if ( $phone ) : ?>
-                    <p><?php echo esc_html( $phone ); ?></p>
-                <?php endif; ?>
-                <?php if ( $email ) : ?>
-                    <p><a href="mailto:<?php echo antispambot( esc_attr( $email ) ); ?>"><?php echo antispambot( esc_html( $email ) ); ?></a></p>
-                <?php endif; ?>
-            </div>
-            <?php endif; ?>
-            <?php if ( $form ) : ?>
-            <div class="wpgmo-item wpgmo-form">
-                <?php echo do_shortcode( $form ); ?>
-            </div>
-            <?php endif; ?>
-            <?php if ( $map ) : ?>
-            <div class="wpgmo-item wpgmo-map">
-                <?php echo $map; ?>
-            </div>
-            <?php endif; ?>
+        <?php foreach ( $layout as $cell ) :
+            $type = $cell['type'];
+            $size = ( isset( $cell['size'] ) && 'large' === $cell['size'] ) ? 'large' : 'small';
+            $classes = 'wpgmo-item wpgmo-' . esc_attr( $type ) . ' size-' . $size;
+            switch ( $type ) {
+                case 'welcome':
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <h2><?php echo esc_html( $welcome ); ?></h2>
+                    </div>
+                    <?php
+                    break;
+                case 'openings':
+                    if ( $hours ) :
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <h2><?php _e( 'Öffnungszeiten', 'wpgmo' ); ?></h2>
+                        <p><?php echo esc_html( $hours ); ?></p>
+                    </div>
+                    <?php
+                    endif;
+                    break;
+                case 'about':
+                    if ( $about ) :
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <h2><?php _e( 'Über uns', 'wpgmo' ); ?></h2>
+                        <p><?php echo esc_html( $about ); ?></p>
+                    </div>
+                    <?php
+                    endif;
+                    break;
+                case 'contact':
+                    if ( $address || $phone || $email ) :
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <h2><?php _e( 'Kontakt', 'wpgmo' ); ?></h2>
+                        <?php if ( $address ) : ?>
+                            <p><?php echo nl2br( esc_html( $address ) ); ?></p>
+                        <?php endif; ?>
+                        <?php if ( $phone ) : ?>
+                            <p><?php echo esc_html( $phone ); ?></p>
+                        <?php endif; ?>
+                        <?php if ( $email ) : ?>
+                            <p><a href="mailto:<?php echo antispambot( esc_attr( $email ) ); ?>"><?php echo antispambot( esc_html( $email ) ); ?></a></p>
+                        <?php endif; ?>
+                    </div>
+                    <?php
+                    endif;
+                    break;
+                case 'form':
+                    if ( $form ) :
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <?php echo do_shortcode( $form ); ?>
+                    </div>
+                    <?php
+                    endif;
+                    break;
+                case 'map':
+                    if ( $map ) :
+                    ?>
+                    <div class="<?php echo $classes; ?>">
+                        <?php echo $map; ?>
+                    </div>
+                    <?php
+                    endif;
+                    break;
+            }
+        endforeach; ?>
         </div>
         <?php
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- allow customizing grid layout for overlay shortcodes
- support `size-large` grid items in CSS
- implement admin UI for managing overlay layout
- document usage in README

## Testing
- `php -l includes/class-wp-grid-menu-overlay.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd56f81888329aee18ce1e6e7a5ab