### PR TITLE
Implement grid overlay templates

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -1545,5 +1545,12 @@ class AIO_Restaurant_Plugin {
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/widgets.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wpgmo-template-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wpgmo-meta-box.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-grid-menu-overlay.php';
+
+WPGMO_Template_Manager::instance();
+WPGMO_Meta_Box::instance();
+WP_Grid_Menu_Overlay::instance();
 
 new AIO_Restaurant_Plugin();

--- a/assets/css/wp-grid-menu-overlay.css
+++ b/assets/css/wp-grid-menu-overlay.css
@@ -1,0 +1,6 @@
+.wpgmo-grid{display:flex;flex-direction:column;gap:10px}
+.wpgmo-row{display:flex;gap:10px}
+.wpgmo-cell{border:1px solid #eee;padding:10px;flex:1}
+.wpgmo-large{flex:2}
+.wpgmo-medium{flex:1}
+.wpgmo-small{flex:0.5}

--- a/assets/css/wpgmo-grid-builder.css
+++ b/assets/css/wpgmo-grid-builder.css
@@ -1,0 +1,3 @@
+#wpgmo-template-manager{padding:20px;background:#fff;border:1px solid #ccc}
+#wpgmo-template-manager .wpgmo-row{display:flex;margin-bottom:10px}
+#wpgmo-template-manager .wpgmo-cell{border:1px dashed #999;padding:10px;flex:1;margin-right:10px}

--- a/assets/js/wpgmo-grid-builder.js
+++ b/assets/js/wpgmo-grid-builder.js
@@ -1,0 +1,22 @@
+jQuery(function($){
+    var templates = WPGMO_GB.templates || {};
+    var container = $('#wpgmo-template-manager');
+    if(!container.length) return;
+    var network = container.data('network');
+
+    function render(){
+        container.empty();
+        $.each(templates, function(slug, tpl){
+            var div = $('<div class="wpgmo-template"/>').append('<strong>'+tpl.label+'</strong> (<em>'+slug+'</em>)');
+            var btn = $('<button class="button">'+WPGMO_GB.setDefault+'</button>').on('click',function(){setDefault(slug);});
+            div.append(btn);
+            container.append(div);
+        });
+    }
+
+    function setDefault(slug){
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_set_default_template',slug:slug,nonce:WPGMO_GB.nonce},render);
+    }
+
+    render();
+});

--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WP_Grid_Menu_Overlay {
+    private static $instance = null;
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_shortcode( 'wp_grid_menu_overlay', array( $this, 'shortcode' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
+    }
+
+    public function enqueue() {
+        wp_enqueue_style( 'wp-grid-menu-overlay', plugin_dir_url( __FILE__ ) . '../assets/css/wp-grid-menu-overlay.css' );
+    }
+
+    private function get_templates() {
+        if ( is_multisite() ) {
+            return array_merge( get_site_option( 'wpgmo_templates_network', array() ), get_option( 'wpgmo_templates', array() ) );
+        }
+        return get_option( 'wpgmo_templates', array() );
+    }
+
+    public function shortcode( $atts ) {
+        global $post;
+        $atts = shortcode_atts( array( 'id' => get_option( 'wpgmo_default_template' ) ), $atts );
+        $templates = $this->get_templates();
+        if ( empty( $templates[ $atts['id'] ] ) ) {
+            return '';
+        }
+        $layout  = $templates[ $atts['id'] ]['layout'];
+        $content = get_post_meta( $post->ID, 'wpgmo_content_' . $atts['id'], true );
+        $html = '<div class="wpgmo-grid">';
+        foreach ( $layout as $row ) {
+            $html .= '<div class="wpgmo-row">';
+            foreach ( $row as $cell ) {
+                $cid   = $cell['id'];
+                $inner = isset( $content[ $cid ] ) ? do_shortcode( wp_kses_post( $content[ $cid ] ) ) : '';
+                $size  = isset( $cell['size'] ) ? $cell['size'] : 'large';
+                $html .= "<div class='wpgmo-cell wpgmo-{$size}'>" . $inner . '</div>';
+            }
+            $html .= '</div>';
+        }
+        $html .= '</div>';
+        return $html;
+    }
+}

--- a/includes/class-wpgmo-meta-box.php
+++ b/includes/class-wpgmo-meta-box.php
@@ -1,0 +1,76 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WPGMO_Meta_Box {
+    private static $instance = null;
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'add_meta_boxes', array( $this, 'add_box' ) );
+        add_action( 'save_post', array( $this, 'save' ) );
+    }
+
+    public function add_box() {
+        add_meta_box( 'wpgmo_box', __('Grid Overlay Content','aorp'), array( $this, 'render_box' ), ['post','page'], 'normal', 'high' );
+    }
+
+    public function render_box( $post ) {
+        $templates_net  = get_site_option( 'wpgmo_templates_network', array() );
+        $templates_site = get_option( 'wpgmo_templates', array() );
+        $default        = get_option( 'wpgmo_default_template', '' );
+        $selected       = get_post_meta( $post->ID, 'wpgmo_template', true );
+        if ( ! $selected ) {
+            $selected = $default;
+        }
+        wp_nonce_field( 'wpgmo_save_meta', 'wpgmo_nonce' );
+        echo '<p><label for="wpgmo_template">'.__('Choose Template','aorp').'</label> ';
+        echo '<select name="wpgmo_template" id="wpgmo_template">';
+        foreach ( $templates_net as $slug => $tpl ) {
+            printf( '<option value="%s" %s>%s</option>', esc_attr( $slug ), selected( $selected, $slug, false ), esc_html( $tpl['label'] ) );
+        }
+        foreach ( $templates_site as $slug => $tpl ) {
+            printf( '<option value="%s" %s>%s</option>', esc_attr( $slug ), selected( $selected, $slug, false ), esc_html( $tpl['label'] ) );
+        }
+        echo '</select></p>';
+        $template = isset( $templates_site[ $selected ] ) ? $templates_site[ $selected ] : ( isset( $templates_net[ $selected ] ) ? $templates_net[ $selected ] : null );
+        $content  = get_post_meta( $post->ID, 'wpgmo_content_' . $selected, true );
+        if ( $template ) {
+            foreach ( $template['layout'] as $row ) {
+                foreach ( $row as $cell ) {
+                    $cid = esc_attr( $cell['id'] );
+                    $val = isset( $content[ $cid ] ) ? esc_textarea( $content[ $cid ] ) : '';
+                    echo '<p><label>'.esc_html( $cid ).'</label><br />';
+                    echo '<textarea name="wpgmo_cells['.$cid.']" rows="3" style="width:100%;">'.$val.'</textarea></p>';
+                }
+            }
+        }
+    }
+
+    public function save( $post_id ) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! isset( $_POST['wpgmo_nonce'] ) || ! wp_verify_nonce( $_POST['wpgmo_nonce'], 'wpgmo_save_meta' ) ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+        $template = isset( $_POST['wpgmo_template'] ) ? sanitize_key( $_POST['wpgmo_template'] ) : '';
+        update_post_meta( $post_id, 'wpgmo_template', $template );
+        $cells = isset( $_POST['wpgmo_cells'] ) && is_array( $_POST['wpgmo_cells'] ) ? wp_unslash( $_POST['wpgmo_cells'] ) : array();
+        $clean = array();
+        foreach ( $cells as $k => $v ) {
+            $clean[ sanitize_key( $k ) ] = wp_kses_post( $v );
+        }
+        update_post_meta( $post_id, 'wpgmo_content_' . $template, $clean );
+    }
+}

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -1,0 +1,118 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WPGMO_Template_Manager {
+    private static $instance = null;
+    private $page_hook = '';
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+        add_action( 'wp_ajax_wpgmo_save_template', array( $this, 'save_template' ) );
+        add_action( 'wp_ajax_wpgmo_delete_template', array( $this, 'delete_template' ) );
+        add_action( 'wp_ajax_wpgmo_set_default_template', array( $this, 'set_default' ) );
+    }
+
+    public function admin_menu() {
+        if ( is_network_admin() ) {
+            $this->page_hook = add_menu_page( __('Grid Templates','aorp'), __('Grid Templates','aorp'), 'manage_network_options', 'wpgmo-templates', array( $this, 'render_page' ) );
+        } else {
+            $this->page_hook = add_menu_page( __('Grid Templates','aorp'), __('Grid Templates','aorp'), 'manage_options', 'wpgmo-templates', array( $this, 'render_page' ) );
+        }
+    }
+
+    public function enqueue( $hook ) {
+        if ( $hook !== $this->page_hook ) {
+            return;
+        }
+        wp_enqueue_style( 'wpgmo-gb-css', plugin_dir_url( __FILE__ ) . '../assets/css/wpgmo-grid-builder.css' );
+        wp_enqueue_script( 'wpgmo-gb-js', plugin_dir_url( __FILE__ ) . '../assets/js/wpgmo-grid-builder.js', array( 'jquery' ), false, true );
+        wp_localize_script( 'wpgmo-gb-js', 'WPGMO_GB', array(
+            'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+            'nonce'     => wp_create_nonce( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb' ),
+            'templates' => is_network_admin() ? get_site_option( 'wpgmo_templates_network', array() ) : get_option( 'wpgmo_templates', array() ),
+            'setDefault'=> __( 'Set default', 'aorp' ),
+        ) );
+    }
+
+    public function render_page() {
+        if ( ! current_user_can( is_network_admin() ? 'manage_network_options' : 'manage_options' ) ) {
+            return;
+        }
+        $is_network = is_network_admin();
+        $default    = $is_network ? get_site_option( 'wpgmo_default_template_network', '' ) : get_option( 'wpgmo_default_template', '' );
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Grid Templates','aorp'); ?></h1>
+            <div id="wpgmo-template-manager" data-network="<?php echo $is_network ? 1 : 0; ?>" data-default="<?php echo esc_attr( $default ); ?>"></div>
+        </div>
+        <?php
+    }
+
+    private function sanitize_template( $data ) {
+        $out = array();
+        $out['label']  = sanitize_text_field( $data['label'] );
+        $out['layout'] = isset( $data['layout'] ) && is_array( $data['layout'] ) ? $data['layout'] : array();
+        return $out;
+    }
+
+    public function save_template() {
+        check_ajax_referer( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb', 'nonce' );
+        if ( ! current_user_can( is_network_admin() ? 'manage_network_options' : 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $slug     = sanitize_key( $_POST['slug'] );
+        $template = $this->sanitize_template( $_POST['template'] );
+        if ( is_network_admin() ) {
+            $templates = get_site_option( 'wpgmo_templates_network', array() );
+            $templates[ $slug ] = $template;
+            update_site_option( 'wpgmo_templates_network', $templates );
+        } else {
+            $templates = get_option( 'wpgmo_templates', array() );
+            $templates[ $slug ] = $template;
+            update_option( 'wpgmo_templates', $templates );
+        }
+        wp_send_json_success();
+    }
+
+    public function delete_template() {
+        check_ajax_referer( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb', 'nonce' );
+        if ( ! current_user_can( is_network_admin() ? 'manage_network_options' : 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $slug = sanitize_key( $_POST['slug'] );
+        if ( is_network_admin() ) {
+            $templates = get_site_option( 'wpgmo_templates_network', array() );
+            unset( $templates[ $slug ] );
+            update_site_option( 'wpgmo_templates_network', $templates );
+        } else {
+            $templates = get_option( 'wpgmo_templates', array() );
+            unset( $templates[ $slug ] );
+            update_option( 'wpgmo_templates', $templates );
+        }
+        wp_send_json_success();
+    }
+
+    public function set_default() {
+        check_ajax_referer( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb', 'nonce' );
+        if ( ! current_user_can( is_network_admin() ? 'manage_network_options' : 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $slug = sanitize_key( $_POST['slug'] );
+        if ( is_network_admin() ) {
+            update_site_option( 'wpgmo_default_template_network', $slug );
+        } else {
+            update_option( 'wpgmo_default_template', $slug );
+        }
+        wp_send_json_success();
+    }
+}


### PR DESCRIPTION
## Summary
- add a template manager to handle grid templates in network and site context
- add meta box for pages and posts to input cell content
- add frontend shortcode renderer
- load new system via main plugin file
- provide simple JS/CSS for admin grid builder and frontend grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be108e4608329b43879198c6479fa