### PR TITLE
Implement interactive grid template manager

### DIFF
--- a/assets/css/wpgmo-grid-builder.css
+++ b/assets/css/wpgmo-grid-builder.css
@@ -1,3 +1,8 @@
 #wpgmo-template-manager{padding:20px;background:#fff;border:1px solid #ccc}
-#wpgmo-template-manager .wpgmo-row{display:flex;margin-bottom:10px}
-#wpgmo-template-manager .wpgmo-cell{border:1px dashed #999;padding:10px;flex:1;margin-right:10px}
+#wpgmo-template-manager table{width:100%;margin-top:10px}
+#wpgmo-template-manager td,#wpgmo-template-manager th{padding:5px}
+#wpgmo-template-manager .wpgmo-editor{margin-top:20px;padding:10px;border:1px solid #ccc;background:#fff}
+#wpgmo-template-manager .wpgmo-row{display:flex;gap:10px;margin-bottom:10px}
+#wpgmo-template-manager .wpgmo-cell{border:1px dashed #999;padding:10px;flex:1;position:relative}
+#wpgmo-template-manager .wpgmo-cell span{display:block;margin-bottom:5px}
+#wpgmo-template-manager .wpgmo-cell select{position:absolute;bottom:5px;right:5px}

--- a/assets/js/wpgmo-grid-builder.js
+++ b/assets/js/wpgmo-grid-builder.js
@@ -3,31 +3,141 @@ jQuery(function($){
     var networkSlugs = WPGMO_GB.networkSlugs || [];
     var container = $('#wpgmo-template-manager');
     if(!container.length) return;
-    var network = container.data('network');
+    var editing = false;
+    var state = null;
+    var nextId = 1;
+
+    function isReadOnly(slug){
+        return !WPGMO_GB.isNetwork && networkSlugs.indexOf(slug) !== -1;
+    }
+
+    function getNextId(layout){
+        var id = 1;
+        $.each(layout,function(_,row){
+            $.each(row,function(_,cell){
+                var n = parseInt(String(cell.id).replace('cell',''),10);
+                if(n >= id){ id = n + 1; }
+            });
+        });
+        return id;
+    }
 
     function render(){
         container.empty();
-        $.each(templates, function(slug, tpl){
-            var div = $('<div class="wpgmo-template"/>').append('<strong>'+tpl.label+'</strong> (<em>'+slug+'</em>)');
-            var btn = $('<button class="button">'+WPGMO_GB.setDefault+'</button>').on('click',function(){setDefault(slug);});
-            var dup = $('<button class="button">'+WPGMO_GB.duplicate+'</button>').on('click',function(){
+        if(state){
+            renderEditor();
+        }else{
+            renderList();
+        }
+    }
+
+    function renderList(){
+        var addBtn = $('<button class="button button-primary"/>').text(WPGMO_GB.new).on('click',function(){
+            state = {slug:'',label:'',layout:[]};
+            nextId = 1;
+            editing = false;
+            render();
+        });
+        container.append(addBtn);
+        var table = $('<table class="widefat striped"><thead><tr><th>Slug</th><th>'+WPGMO_GB.label+'</th><th>'+WPGMO_GB.actions+'</th></tr></thead><tbody></tbody></table>');
+        $.each(templates,function(slug,tpl){
+            var tr = $('<tr/>');
+            var slugCell = $('<td/>').text(slug);
+            if(slug === WPGMO_GB.default){ slugCell.append(' *'); }
+            tr.append(slugCell);
+            tr.append($('<td/>').text(tpl.label));
+            var actions = $('<td/>');
+            var editB = $('<button class="button"/>').text(WPGMO_GB.edit).on('click',function(){
+                if(isReadOnly(slug)) return;
+                state = {slug:slug,label:tpl.label,layout:tpl.layout||[]};
+                nextId = getNextId(state.layout);
+                editing = true;
+                render();
+            });
+            var dupB = $('<button class="button"/>').text(WPGMO_GB.duplicate).on('click',function(){
                 var ns = prompt('Slug');
                 if(ns){ duplicateTemplate(slug,ns); }
             });
-            if(!WPGMO_GB.isNetwork && networkSlugs.indexOf(slug) !== -1){
-                dup.prop('disabled', true);
+            var delB = $('<button class="button"/>').text(WPGMO_GB.del).on('click',function(){ deleteTemplate(slug); });
+            var defB = $('<button class="button"/>').text(WPGMO_GB.setDefault).on('click',function(){ setDefault(slug); });
+            if(isReadOnly(slug)){
+                editB.prop('disabled',true);
+                delB.prop('disabled',true);
             }
-            div.append(btn).append(dup);
-            container.append(div);
+            actions.append(editB).append(' ').append(dupB).append(' ').append(delB).append(' ').append(defB);
+            tr.append(actions);
+            table.find('tbody').append(tr);
+        });
+        container.append(table);
+    }
+
+    function renderEditor(){
+        var wrap = $('<div class="wpgmo-editor"/>');
+        wrap.append('<p><label>'+WPGMO_GB.slug+'</label><br><input type="text" id="wpgmo-slug" '+(editing?'readonly':'')+' value="'+state.slug+'"></p>');
+        wrap.append('<p><label>'+WPGMO_GB.label+'</label><br><input type="text" id="wpgmo-label" value="'+state.label+'"></p>');
+        var layoutDiv = $('<div id="wpgmo-layout"/>');
+        $.each(state.layout,function(i,row){
+            var rdiv = $('<div class="wpgmo-row"/>');
+            $.each(row,function(j,cell){
+                var cdiv = $('<div class="wpgmo-cell"/>');
+                cdiv.append('<span>'+cell.id+'</span>');
+                var sel = $('<select><option value="large">Large</option><option value="medium">Medium</option><option value="small">Small</option></select>');
+                sel.val(cell.size);
+                sel.on('change',function(){ cell.size = $(this).val(); });
+                cdiv.append(sel);
+                rdiv.append(cdiv);
+            });
+            var addC = $('<button class="button">+ Column</button>').on('click',function(){ addColumn(i); });
+            rdiv.append(addC);
+            layoutDiv.append(rdiv);
+        });
+        layoutDiv.append($('<button class="button">+ Row</button>').on('click',addRow));
+        wrap.append(layoutDiv);
+        var save = $('<button class="button button-primary"/>').text(WPGMO_GB.save).on('click',function(e){ e.preventDefault(); saveTemplate(); });
+        var cancel = $('<button class="button"/>').text(WPGMO_GB.cancel).on('click',function(e){ e.preventDefault(); state=null; render(); });
+        wrap.append(save).append(' ').append(cancel);
+        container.append(wrap);
+    }
+
+    function addRow(){
+        state.layout.push([{id:'cell'+(nextId++),size:'large'}]);
+        render();
+    }
+
+    function addColumn(index){
+        state.layout[index].push({id:'cell'+(nextId++),size:'medium'});
+        render();
+    }
+
+    function saveTemplate(){
+        state.slug = $('#wpgmo-slug').val().trim();
+        state.label = $('#wpgmo-label').val().trim();
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_save_template',nonce:WPGMO_GB.nonce,slug:state.slug,template:{label:state.label,layout:state.layout}},function(resp){
+            if(resp.success){
+                templates[state.slug] = {label:state.label,layout:state.layout};
+                state = null;
+                render();
+            }
+        });
+    }
+
+    function deleteTemplate(slug){
+        if(!confirm(WPGMO_GB.confirm)) return;
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_delete_template',slug:slug,nonce:WPGMO_GB.nonce},function(resp){
+            if(resp.success){ delete templates[slug]; render(); }
+        });
+    }
+
+    function duplicateTemplate(slug,newSlug){
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_duplicate_template',slug:slug,new_slug:newSlug,nonce:WPGMO_GB.nonce},function(resp){
+            if(resp.success){ templates[newSlug]=templates[slug]; render(); }
         });
     }
 
     function setDefault(slug){
-        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_set_default_template',slug:slug,nonce:WPGMO_GB.nonce},render);
-    }
-
-    function duplicateTemplate(slug,newSlug){
-        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_duplicate_template',slug:slug,new_slug:newSlug,nonce:WPGMO_GB.nonce},function(resp){if(resp.success){templates[newSlug]=templates[slug];render();}});
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_set_default_template',slug:slug,nonce:WPGMO_GB.nonce},function(resp){
+            if(resp.success){ WPGMO_GB.default = slug; render(); }
+        });
     }
 
     render();

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -42,14 +42,25 @@ class WPGMO_Template_Manager {
         $templates = is_network_admin()
             ? $network_templates
             : array_merge( $network_templates, get_option( 'wpgmo_templates', array() ) );
+        $default = is_network_admin() ? get_site_option( 'wpgmo_default_template_network', '' ) : get_option( 'wpgmo_default_template', '' );
         wp_localize_script( 'wpgmo-gb-js', 'WPGMO_GB', array(
-            'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
-            'nonce'          => wp_create_nonce( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb' ),
-            'templates'      => $templates,
-            'networkSlugs'   => array_keys( $network_templates ),
-            'setDefault'     => __( 'Set default', 'aorp' ),
-            'duplicate'      => __( 'Duplicate', 'aorp' ),
-            'isNetwork'      => is_network_admin() ? 1 : 0,
+            'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+            'nonce'        => wp_create_nonce( is_network_admin() ? 'wpgmo_gb_network' : 'wpgmo_gb' ),
+            'templates'    => $templates,
+            'networkSlugs' => array_keys( $network_templates ),
+            'isNetwork'    => is_network_admin() ? 1 : 0,
+            'setDefault'   => __( 'Set default', 'aorp' ),
+            'duplicate'    => __( 'Duplicate', 'aorp' ),
+            'edit'         => __( 'Edit', 'aorp' ),
+            'del'          => __( 'Delete', 'aorp' ),
+            'new'          => __( 'New Template', 'aorp' ),
+            'save'         => __( 'Save Template', 'aorp' ),
+            'cancel'       => __( 'Cancel', 'aorp' ),
+            'slug'         => __( 'Slug', 'aorp' ),
+            'label'        => __( 'Label', 'aorp' ),
+            'actions'      => __( 'Actions', 'aorp' ),
+            'confirm'      => __( 'Delete this template?', 'aorp' ),
+            'default'      => $default,
         ) );
     }
 


### PR DESCRIPTION
## Summary
- add CSS styles for template management
- add interactive JS grid editor with create/edit/delete actions
- localize new JS strings and default slug in template manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be3f7957c8329b6117d9c22c6c8c5