### PR TITLE
Add grid management improvements

### DIFF
--- a/assets/css/wpgmo-grid-builder.css
+++ b/assets/css/wpgmo-grid-builder.css
@@ -6,3 +6,5 @@
 #wpgmo-template-manager .wpgmo-cell{border:1px dashed #999;padding:10px;flex:1;position:relative}
 #wpgmo-template-manager .wpgmo-cell span{display:block;margin-bottom:5px}
 #wpgmo-template-manager .wpgmo-cell select{position:absolute;bottom:5px;right:5px}
+#wpgmo-template-manager .remove-cell{position:absolute;top:2px;right:2px;background:#f00;color:#fff;border:none;padding:0 5px;cursor:pointer}
+#wpgmo-template-manager .remove-row{margin-left:5px}

--- a/assets/js/wpgmo-grid-builder.js
+++ b/assets/js/wpgmo-grid-builder.js
@@ -85,10 +85,13 @@ jQuery(function($){
                 sel.val(cell.size);
                 sel.on('change',function(){ cell.size = $(this).val(); });
                 cdiv.append(sel);
+                var del = $('<button type="button" class="remove-cell">&times;</button>').on('click',function(){ removeColumn(i,j); });
+                cdiv.append(del);
                 rdiv.append(cdiv);
             });
             var addC = $('<button class="button">+ Column</button>').on('click',function(){ addColumn(i); });
-            rdiv.append(addC);
+            var delR = $('<button class="button remove-row"/>').text(WPGMO_GB.removeRow).on('click',function(){ removeRow(i); });
+            rdiv.append(addC).append(delR);
             layoutDiv.append(rdiv);
         });
         layoutDiv.append($('<button class="button">+ Row</button>').on('click',addRow));
@@ -106,6 +109,19 @@ jQuery(function($){
 
     function addColumn(index){
         state.layout[index].push({id:'cell'+(nextId++),size:'medium'});
+        render();
+    }
+
+    function removeColumn(rowIndex,colIndex){
+        state.layout[rowIndex].splice(colIndex,1);
+        if(state.layout[rowIndex].length===0){
+            state.layout.splice(rowIndex,1);
+        }
+        render();
+    }
+
+    function removeRow(rowIndex){
+        state.layout.splice(rowIndex,1);
         render();
     }
 


### PR DESCRIPTION
## Summary
- enable deleting rows and cells while editing grid templates
- style delete buttons in grid builder
- add Grid Overview page for viewing all templates

## Testing
- `php -l includes/class-wpgmo-template-manager.php`
- `php -l all-in-one-restaurant-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_685be54a0994832988cb65a3eab1137a