### PR TITLE
Add default grid template and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,17 @@ Du findest die Vorlagen direkt auf der Import/Export-Seite:
 Lade die gewünschte Datei herunter, trage deine Daten ein und importiere sie anschließend wieder über das Formular.
 Beim YAML-Format können Nummern und Preise ohne Anführungszeichen angegeben werden. Eventuell vorhandene Anführungszeichen werden beim Import automatisch entfernt.
 
+### Grid-Vorlagen
+
+Unter **Grid Templates** verwaltest du Rasterlayouts für den Shortcode `[wp_grid_menu_overlay]`.
+Nach der Installation ist bereits eine Beispielvorlage vorhanden, die du bearbeiten kannst.
+
+1. Öffne im Admin-Bereich den Menüpunkt **Grid Templates**.
+2. Mit *New Template* legst du ein neues Raster an, über *Edit* passt du bestehende Vorlagen an.
+3. Innerhalb des Editors kannst du Zeilen und Spalten hinzufügen oder entfernen und für jede Zelle die Größe wählen.
+4. Speichere das Raster. In der Liste lassen sich Vorlagen duplizieren, löschen oder als Standard markieren.
+
+Auf Beitrags- und Seitenbearbeitungen erscheint die Metabox **Grid Overlay Content**.
+Dort wählst du eine Vorlage aus und fügst die Inhalte für jede Zelle ein.
+Der Shortcode gibt anschließend das definierte Raster auf der Seite aus.
+

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: All-In-One WordPress Restaurant Plugin
 Description: Umfangreiches Speisekarten-Plugin mit Dark‑Mode, Suchfunktion und Import/Export.
-Version: 1.4.0
+Version: 1.4.1
 Author: stb-srv
 */
 
@@ -1548,6 +1548,32 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/widgets.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wpgmo-template-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wpgmo-meta-box.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wp-grid-menu-overlay.php';
+
+function aio_restaurant_activate() {
+    $templates = is_multisite()
+        ? get_site_option( 'wpgmo_templates_network', array() )
+        : get_option( 'wpgmo_templates', array() );
+    if ( empty( $templates ) ) {
+        $templates['beispiel'] = array(
+            'label'  => 'Beispiel Grid',
+            'layout' => array(
+                array(
+                    array( 'id' => 'cell1', 'size' => 'large' ),
+                    array( 'id' => 'cell2', 'size' => 'large' ),
+                ),
+            ),
+        );
+        if ( is_multisite() ) {
+            update_site_option( 'wpgmo_templates_network', $templates );
+            update_site_option( 'wpgmo_default_template_network', 'beispiel' );
+        } else {
+            update_option( 'wpgmo_templates', $templates );
+            update_option( 'wpgmo_default_template', 'beispiel' );
+        }
+    }
+}
+
+register_activation_hook( __FILE__, 'aio_restaurant_activate' );
 
 WPGMO_Template_Manager::instance();
 WPGMO_Meta_Box::instance();


### PR DESCRIPTION
## Summary
- create default grid template on activation
- document grid templates in README

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `find . -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_685be8ed2b1c83299bb422d574a18622