### PR TITLE
Enable visual editor for grid cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,6 @@ Nach der Installation ist bereits eine Beispielvorlage vorhanden, die du bearbei
 
 Auf Beitrags- und Seitenbearbeitungen erscheint die Metabox **Grid Overlay Content**.
 Dort wählst du eine Vorlage aus und fügst die Inhalte für jede Zelle ein.
+Für jede Zelle steht ein visueller Editor bereit, mit dem du Texte, Bilder oder Shortcodes komfortabel einfügst.
 Der Shortcode gibt anschließend das definierte Raster auf der Seite aus.
 

--- a/includes/class-wpgmo-meta-box.php
+++ b/includes/class-wpgmo-meta-box.php
@@ -46,9 +46,14 @@ class WPGMO_Meta_Box {
             foreach ( $template['layout'] as $row ) {
                 foreach ( $row as $cell ) {
                     $cid = esc_attr( $cell['id'] );
-                    $val = isset( $content[ $cid ] ) ? esc_textarea( $content[ $cid ] ) : '';
-                    echo '<p><label>'.esc_html( $cid ).'</label><br />';
-                    echo '<textarea name="wpgmo_cells['.$cid.']" rows="3" style="width:100%;">'.$val.'</textarea></p>';
+                    $val = isset( $content[ $cid ] ) ? wp_kses_post( $content[ $cid ] ) : '';
+                    echo '<p><label>'.esc_html( $cid ).'</label></p>';
+                    wp_editor( $val, 'wpgmo_cell_' . $cid, array(
+                        'textarea_name' => 'wpgmo_cells['.$cid.']',
+                        'textarea_rows' => 5,
+                        'media_buttons' => true,
+                        'teeny'         => true,
+                    ) );
                 }
             }
         }


### PR DESCRIPTION
## Summary
- use `wp_editor` for editing grid cells
- document grid editing with the new visual editor

## Testing
- `php -l includes/class-wpgmo-meta-box.php`


------
https://chatgpt.com/codex/tasks/task_e_685beb62a3ec83298b991774016096f6