### PR TITLE
Add grid content editing and German UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,18 @@ Beim YAML-Format können Nummern und Preise ohne Anführungszeichen angegeben we
 
 ### Grid-Vorlagen
 
-Unter **Grid Templates** verwaltest du Rasterlayouts für den Shortcode `[wp_grid_menu_overlay]`.
+Unter **Grid-Vorlagen** verwaltest du Rasterlayouts für den Shortcode `[wp_grid_menu_overlay]`.
 Nach der Installation ist bereits eine Beispielvorlage vorhanden, die du bearbeiten kannst.
 
-1. Öffne im Admin-Bereich den Menüpunkt **Grid Templates**.
-2. Mit *New Template* legst du ein neues Raster an, über *Edit* passt du bestehende Vorlagen an.
+1. Öffne im Admin-Bereich den Menüpunkt **Grid-Vorlagen**.
+2. Mit *Neue Vorlage* legst du ein neues Raster an, über *Bearbeiten* passt du bestehende Vorlagen an.
 3. Innerhalb des Editors kannst du Zeilen und Spalten hinzufügen oder entfernen und für jede Zelle die Größe wählen.
 4. Speichere das Raster. In der Liste lassen sich Vorlagen duplizieren, löschen oder als Standard markieren.
 
-Auf Beitrags- und Seitenbearbeitungen erscheint die Metabox **Grid Overlay Content**.
+Auf Beitrags- und Seitenbearbeitungen erscheint die Metabox **Grid-Overlay Inhalt**.
 Dort wählst du eine Vorlage aus und fügst die Inhalte für jede Zelle ein.
 Für jede Zelle steht ein visueller Editor bereit, mit dem du Texte, Bilder oder Shortcodes komfortabel einfügst.
 Der Shortcode gibt anschließend das definierte Raster auf der Seite aus.
+
+Unter **Grid-Inhalte** kannst du außerdem Standardinhalte für jede Zelle einer Vorlage hinterlegen. Diese werden angezeigt, wenn ein Beitrag keine eigenen Inhalte besitzt.
 

--- a/assets/js/wpgmo-grid-builder.js
+++ b/assets/js/wpgmo-grid-builder.js
@@ -81,7 +81,7 @@ jQuery(function($){
             $.each(row,function(j,cell){
                 var cdiv = $('<div class="wpgmo-cell"/>');
                 cdiv.append('<span>'+cell.id+'</span>');
-                var sel = $('<select><option value="large">Large</option><option value="medium">Medium</option><option value="small">Small</option></select>');
+                var sel = $('<select><option value="large">Groß</option><option value="medium">Mittel</option><option value="small">Klein</option></select>');
                 sel.val(cell.size);
                 sel.on('change',function(){ cell.size = $(this).val(); });
                 cdiv.append(sel);
@@ -89,12 +89,12 @@ jQuery(function($){
                 cdiv.append(del);
                 rdiv.append(cdiv);
             });
-            var addC = $('<button class="button">+ Column</button>').on('click',function(){ addColumn(i); });
+            var addC = $('<button class="button">+ Spalte</button>').on('click',function(){ addColumn(i); });
             var delR = $('<button class="button remove-row"/>').text(WPGMO_GB.removeRow).on('click',function(){ removeRow(i); });
             rdiv.append(addC).append(delR);
             layoutDiv.append(rdiv);
         });
-        layoutDiv.append($('<button class="button">+ Row</button>').on('click',addRow));
+        layoutDiv.append($('<button class="button">+ Zeile</button>').on('click',addRow));
         wrap.append(layoutDiv);
         var save = $('<button class="button button-primary"/>').text(WPGMO_GB.save).on('click',function(e){ e.preventDefault(); saveTemplate(); });
         var cancel = $('<button class="button"/>').text(WPGMO_GB.cancel).on('click',function(e){ e.preventDefault(); state=null; render(); });

--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -37,14 +37,22 @@ class WP_Grid_Menu_Overlay {
         if ( empty( $templates[ $atts['id'] ] ) ) {
             return '';
         }
-        $layout  = $templates[ $atts['id'] ]['layout'];
-        $content = get_post_meta( $post->ID, 'wpgmo_content_' . $atts['id'], true );
+        $layout   = $templates[ $atts['id'] ]['layout'];
+        $content  = get_post_meta( $post->ID, 'wpgmo_content_' . $atts['id'], true );
+        $defaults = get_option( 'wpgmo_default_content', array() );
+        $tpl_def  = isset( $defaults[ $atts['id'] ] ) ? $defaults[ $atts['id'] ] : array();
         $html = '<div class="wpgmo-grid">';
         foreach ( $layout as $row ) {
             $html .= '<div class="wpgmo-row">';
             foreach ( $row as $cell ) {
                 $cid   = $cell['id'];
-                $inner = isset( $content[ $cid ] ) ? do_shortcode( wp_kses_post( $content[ $cid ] ) ) : '';
+                if ( ! empty( $content[ $cid ] ) ) {
+                    $inner = do_shortcode( wp_kses_post( $content[ $cid ] ) );
+                } elseif ( isset( $tpl_def[ $cid ] ) ) {
+                    $inner = do_shortcode( wp_kses_post( $tpl_def[ $cid ] ) );
+                } else {
+                    $inner = '';
+                }
                 $size  = isset( $cell['size'] ) ? $cell['size'] : 'large';
                 $html .= "<div class='wpgmo-cell wpgmo-{$size}'>" . $inner . '</div>';
             }

--- a/includes/class-wpgmo-meta-box.php
+++ b/includes/class-wpgmo-meta-box.php
@@ -19,7 +19,7 @@ class WPGMO_Meta_Box {
     }
 
     public function add_box() {
-        add_meta_box( 'wpgmo_box', __('Grid Overlay Content','aorp'), array( $this, 'render_box' ), ['post','page'], 'normal', 'high' );
+        add_meta_box( 'wpgmo_box', __('Grid-Overlay Inhalt','aorp'), array( $this, 'render_box' ), ['post','page'], 'normal', 'high' );
     }
 
     public function render_box( $post ) {
@@ -31,7 +31,7 @@ class WPGMO_Meta_Box {
             $selected = $default;
         }
         wp_nonce_field( 'wpgmo_save_meta', 'wpgmo_nonce' );
-        echo '<p><label for="wpgmo_template">'.__('Choose Template','aorp').'</label> ';
+        echo '<p><label for="wpgmo_template">'.__('Vorlage wählen','aorp').'</label> ';
         echo '<select name="wpgmo_template" id="wpgmo_template">';
         foreach ( $templates_net as $slug => $tpl ) {
             printf( '<option value="%s" %s>%s</option>', esc_attr( $slug ), selected( $selected, $slug, false ), esc_html( $tpl['label'] ) );


### PR DESCRIPTION
## Summary
- translate grid manager UI to German
- allow default grid contents via **Grid-Inhalte** page
- fall back to default grid content in shortcode
- localize grid builder buttons
- update README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beca157d08329a59a0d62665835e9