### PR TITLE
Improve grid responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,8 @@ Dort wählst du eine Vorlage aus und fügst die Inhalte für jede Zelle ein.
 Für jede Zelle steht ein visueller Editor bereit, mit dem du Texte, Bilder oder Shortcodes komfortabel einfügst.
 Der Shortcode gibt anschließend das definierte Raster auf der Seite aus.
 
+Das Raster passt sich automatisch der Bildschirmgröße an. Auf mobilen Geräten
+werden alle Zellen untereinander in einer Spalte angezeigt.
+
 Unter **Grid-Inhalte** kannst du außerdem Standardinhalte für jede Zelle einer Vorlage hinterlegen. Diese werden angezeigt, wenn ein Beitrag keine eigenen Inhalte besitzt.
 

--- a/assets/css/wp-grid-menu-overlay.css
+++ b/assets/css/wp-grid-menu-overlay.css
@@ -1,6 +1,7 @@
 .wpgmo-grid{display:flex;flex-direction:column;gap:10px}
-.wpgmo-row{display:flex;gap:10px}
+.wpgmo-row{display:flex;gap:10px;flex-wrap:wrap}
 .wpgmo-cell{border:1px solid #eee;padding:10px;flex:1}
 .wpgmo-large{flex:2}
 .wpgmo-medium{flex:1}
 .wpgmo-small{flex:0.5}
+@media (max-width:600px){.wpgmo-row{flex-direction:column}}


### PR DESCRIPTION
## Summary
- allow grid rows to wrap
- stack grid cells vertically on small screens
- document responsive behavior

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bef3e945483298a4a1e0551e96889