### PR TITLE
Add interactive admin map

### DIFF
--- a/assets/css/map.css
+++ b/assets/css/map.css
@@ -1,2 +1,3 @@
 #aio-leaflet-map{width:100%;height:400px;}
 @media (prefers-color-scheme: dark){.leaflet-container{background:#2b2b2b;}}
+#aio-leaflet-map-admin{width:100%;height:400px;margin-bottom:10px;}

--- a/assets/js/map-admin.js
+++ b/assets/js/map-admin.js
@@ -1,0 +1,32 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        var mapEl = document.getElementById('aio-leaflet-map-admin');
+        var latInput = document.getElementById('aio_leaflet_lat');
+        var lngInput = document.getElementById('aio_leaflet_lng');
+        var zoomInput = document.getElementById('aio_leaflet_zoom');
+        if(!mapEl || !latInput || !lngInput) return;
+        var lat = parseFloat(latInput.value) || 0;
+        var lng = parseFloat(lngInput.value) || 0;
+        var zoom = parseInt(zoomInput ? zoomInput.value : 13, 10) || 13;
+        var map = L.map(mapEl).setView([lat, lng], zoom);
+        var dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var tileUrl = dark ?
+            'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' :
+            'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        L.tileLayer(tileUrl, { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+        var marker = L.marker([lat, lng]).addTo(map);
+        function setInputs(latlng){
+            latInput.value = latlng.lat.toFixed(6);
+            lngInput.value = latlng.lng.toFixed(6);
+        }
+        map.on('click', function(e){
+            marker.setLatLng(e.latlng);
+            setInputs(e.latlng);
+        });
+        if(zoomInput){
+            map.on('zoomend', function(){
+                zoomInput.value = map.getZoom();
+            });
+        }
+    });
+})();

--- a/includes/maps.php
+++ b/includes/maps.php
@@ -8,6 +8,7 @@ class AIO_Leaflet_Map {
     public function __construct() {
         add_action( 'admin_menu', array( $this, 'admin_menu' ) );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_assets' ) );
         add_shortcode( 'aio_leaflet_map', array( $this, 'render_shortcode' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_assets' ) );
     }
@@ -19,6 +20,17 @@ class AIO_Leaflet_Map {
         register_setting( 'aio_leaflet_map', 'aio_leaflet_popup' );
     }
 
+    public function admin_enqueue_assets( $hook ) {
+        if ( 'toplevel_page_aio_leaflet_map' !== $hook ) {
+            return;
+        }
+        $plugin_url = plugin_dir_url( __FILE__ );
+        wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css' );
+        wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), null, true );
+        wp_enqueue_style( 'aio-leaflet-map', $plugin_url . '../assets/css/map.css' );
+        wp_enqueue_script( 'aio-leaflet-map-admin', $plugin_url . '../assets/js/map-admin.js', array( 'leaflet' ), null, true );
+    }
+
     public function admin_menu() {
         add_menu_page( 'Karten', 'Karten', 'manage_options', 'aio_leaflet_map', array( $this, 'settings_page' ), 'dashicons-location-alt' );
     }
@@ -27,6 +39,7 @@ class AIO_Leaflet_Map {
         ?>
         <div class="wrap">
             <h1>Karten Einstellungen</h1>
+            <div id="aio-leaflet-map-admin"></div>
             <form method="post" action="options.php">
                 <?php settings_fields( 'aio_leaflet_map' ); ?>
                 <table class="form-table">


### PR DESCRIPTION
## Summary
- add clickable Leaflet map to admin settings
- load admin assets for Leaflet map editor
- style admin map container

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bf8bef9b48329beeba2b64013e363