### PR TITLE
Fix shortcodes in menu item tiles

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -562,7 +562,8 @@ class AIO_Restaurant_Plugin {
         echo '<span class="aorp-title">' . get_the_title() . '</span>';
         echo '<span class="aorp-price">' . esc_html( $this->format_price( $price ) ) . '</span>';
         echo '</div>';
-        echo '<div class="aorp-desc">' . get_the_content() . '</div>';
+        $content = apply_filters( 'the_content', get_the_content() );
+        echo '<div class="aorp-desc">' . $content . '</div>';
         if ( $ingredient_names ) {
             echo '<div class="aorp-ingredients"><em>' . esc_html( $ingredient_names ) . '</em></div>';
         }


### PR DESCRIPTION
## Summary
- allow shortcode parsing for menu item descriptions

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `for f in $(find . -name '*.php'); do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_685bf9ed1ed08329a2eeadf381f3e810