### PR TITLE
Add dynamic navigation link to map popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Die Widgets "Speisekarte" und "Lightswitcher" können ebenfalls in Sidebars verw
 
 Über den Menüpunkt **Karten** legst du Latitude, Longitude, Zoomstufe und einen Popup-Text fest.
 Diese Werte werden vom `[aio_leaflet_map]`‑Shortcode verwendet.
+Im Popup erscheint jetzt automatisch ein Link, über den Besucher:innen direkt eine Navigation starten können.
 
 ```
 [aio_leaflet_map]

--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -14,6 +14,17 @@
             'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png' :
             'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
         L.tileLayer(tileUrl, { attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
-        L.marker([lat, lng]).addTo(map).bindPopup(popup);
+
+        var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+        var navLink = isIOS ?
+            'http://maps.apple.com/?daddr=' + lat + ',' + lng :
+            'https://www.google.com/maps/dir/?api=1&destination=' + lat + ',' + lng;
+        var popupHtml = '';
+        if(popup){
+            popupHtml += popup + '<br>';
+        }
+        popupHtml += '\uD83D\uDCCD <a href="' + navLink + '" target="_blank">Route starten</a>';
+
+        L.marker([lat, lng]).addTo(map).bindPopup(popupHtml);
     });
 })();


### PR DESCRIPTION
## Summary
- add navigation link to Leaflet map popup with automatic iOS/Google Maps detection
- mention new navigation link in documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c046d09708329afd2178af5dd0497