### PR TITLE
Fix contact form shortcode rendering

### DIFF
--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -47,9 +47,9 @@ class WP_Grid_Menu_Overlay {
             foreach ( $row as $cell ) {
                 $cid   = $cell['id'];
                 if ( ! empty( $content[ $cid ] ) ) {
-                    $inner = do_shortcode( aorp_wp_kses_post_iframe( $content[ $cid ] ) );
+                    $inner = apply_filters( 'the_content', aorp_wp_kses_post_iframe( $content[ $cid ] ) );
                 } elseif ( isset( $tpl_def[ $cid ] ) ) {
-                    $inner = do_shortcode( aorp_wp_kses_post_iframe( $tpl_def[ $cid ] ) );
+                    $inner = apply_filters( 'the_content', aorp_wp_kses_post_iframe( $tpl_def[ $cid ] ) );
                 } else {
                     $inner = '';
                 }


### PR DESCRIPTION
## Summary
- render cell content via `the_content` filter so shortcodes like `[contact-form]` are expanded correctly

## Testing
- `php -l includes/class-wp-grid-menu-overlay.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c070462e88329b0fdf7c7a5cc6b9c