### PR TITLE
Ensure shortcodes are processed in grid overlay

### DIFF
--- a/includes/class-wp-grid-menu-overlay.php
+++ b/includes/class-wp-grid-menu-overlay.php
@@ -47,12 +47,14 @@ class WP_Grid_Menu_Overlay {
             foreach ( $row as $cell ) {
                 $cid   = $cell['id'];
                 if ( ! empty( $content[ $cid ] ) ) {
-                    $inner = apply_filters( 'the_content', aorp_wp_kses_post_iframe( $content[ $cid ] ) );
+                    $raw   = $content[ $cid ];
                 } elseif ( isset( $tpl_def[ $cid ] ) ) {
-                    $inner = apply_filters( 'the_content', aorp_wp_kses_post_iframe( $tpl_def[ $cid ] ) );
+                    $raw   = $tpl_def[ $cid ];
                 } else {
-                    $inner = '';
+                    $raw   = '';
                 }
+                $inner = apply_filters( 'the_content', aorp_wp_kses_post_iframe( $raw ) );
+                $inner = do_shortcode( $inner );
                 $size  = isset( $cell['size'] ) ? $cell['size'] : 'large';
                 $html .= "<div class='wpgmo-cell wpgmo-{$size}'>" . $inner . '</div>';
             }


### PR DESCRIPTION
## Summary
- render shortcodes stored in grid cells

## Testing
- `php -l includes/class-wp-grid-menu-overlay.php`


------
https://chatgpt.com/codex/tasks/task_e_685c0871a5a88329a52871e87541e7fc