### PR TITLE
Add sorting and drink menu support

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -23,6 +23,24 @@ jQuery(document).ready(function($){
         });
     });
 
+    var aorpSortDir = 'asc';
+    $('#aorp-number-sort').on('click', function(e){
+        e.preventDefault();
+        var rows = $('#aorp-items-table tbody tr').get();
+        rows.sort(function(a,b){
+            var A = parseFloat($(a).find('td').eq(4).text()) || 0;
+            var B = parseFloat($(b).find('td').eq(4).text()) || 0;
+            if(aorpSortDir === 'asc'){
+                return A - B;
+            }
+            return B - A;
+        });
+        $.each(rows, function(i,row){
+            $('#aorp-items-table tbody').append(row);
+        });
+        aorpSortDir = aorpSortDir === 'asc' ? 'desc' : 'asc';
+    });
+
     function updateInput(container){
         var list = [];
         container.find('.aorp-ing-chip').each(function(){


### PR DESCRIPTION
## Summary
- fix ingredient field not to overwrite description
- sort items by number on front-end
- allow admin list sorting by number
- add basic drink menu post type and shortcode

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l assets/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68712d73da7883298c507ee7bada4482