### PR TITLE
Add drink menu categories

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -15,6 +15,8 @@ body.aorp-dark .aorp-close-cats{background:#444;color:#fff;border-color:#666}
 .aorp-price{font-weight:bold;margin-left:0.5em}
 .aorp-desc{font-size:0.9em;margin-bottom:0.2em}
 .aorp-ingredients{font-size:0.8em;color:#666}
+.aorp-drink-sizes{list-style:none;margin:0 0 .5em 0;padding:0}
+.aorp-drink-sizes li{display:flex;justify-content:space-between}
 .columns-2 .aorp-category{width:48%;float:left;margin-right:1%}
 .columns-3 .aorp-category{width:31%;float:left;margin-right:1%}
 .columns-2 .aorp-items,.columns-3 .aorp-items{width:100%;float:none;clear:both;margin-right:0}


### PR DESCRIPTION
## Summary
- add custom taxonomy for drink categories
- register drink items under "Speisekarte" menu
- style drink sizes list like food menu
- enhance drink shortcode with category view and search overlay

## Testing
- `php -l all-in-one-restaurant-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6871319cb9888329814a513cde298cc1