### PR TITLE
Add default drink category and improve layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -6,7 +6,7 @@
 body.aorp-dark .aorp-close-cats{background:#444;color:#fff;border-color:#666}
 .aorp-category{cursor:pointer;background:#eee;padding:0.5em;margin-bottom:0.5em;display:flex;align-items:center;min-height:40px;height:60px;line-height:1.2;box-sizing:border-box;border-radius:6px;box-shadow:0 1px 2px rgba(0,0,0,0.1)}
 .aorp-items{display:none;padding-left:1em;box-sizing:border-box}
-.aorp-item{display:flex;margin:1em 0;padding:1em;border:1px solid #ddd;border-radius:6px;box-shadow:0 1px 2px rgba(0,0,0,0.05)}
+.aorp-item{display:flex;margin:1.5em 0;padding:1em;border:1px solid #ddd;border-radius:6px;box-shadow:0 1px 2px rgba(0,0,0,0.05)}
 .aorp-item img{margin-right:0.75em;max-width:80px;height:auto;border-radius:4px}
 .aorp-text{flex:1}
 .aorp-header{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:0.3em}
@@ -17,9 +17,11 @@ body.aorp-dark .aorp-close-cats{background:#444;color:#fff;border-color:#666}
 .aorp-ingredients{font-size:0.8em;color:#666}
 .aorp-drink-sizes{list-style:none;margin:0 0 .5em 0;padding:0}
 .aorp-drink-sizes li{display:flex;justify-content:space-between}
-.aorp-drink-table{width:100%;border-collapse:collapse;margin:0 0 .5em}
-.aorp-drink-table th,.aorp-drink-table td{padding:0.2em 0.5em;text-align:left}
+.aorp-drink-table{width:100%;border-collapse:collapse;margin:0 0 1em}
+.aorp-drink-table th,.aorp-drink-table td{padding:0.4em 0.5em;text-align:left}
 .aorp-drink-table th{font-weight:bold}
+.aorp-drink-table tbody tr{border-bottom:1px solid #ddd}
+.aorp-drink-table tbody tr:last-child{border-bottom:none}
 .columns-2 .aorp-category{width:48%;float:left;margin-right:1%}
 .columns-3 .aorp-category{width:31%;float:left;margin-right:1%}
 .columns-2 .aorp-items,.columns-3 .aorp-items{width:100%;float:none;clear:both;margin-right:0}


### PR DESCRIPTION
## Summary
- tweak margins and table spacing for drinks
- render volume header once per drink category
- ensure a default drink category exists and can't be deleted
- assign the default drink category when none selected
- hide delete links for the default drink category

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `csslint assets/style.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871419bca2c8329a91104c78b8a6811