### PR TITLE
Fix drink legend placement

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -925,7 +925,6 @@ class AIO_Restaurant_Plugin {
         $terms = get_terms( $args );
 
         if ( empty( $terms ) ) {
-            $this->ingredient_numbers = array();
             $query = new WP_Query( array(
                 'post_type'      => 'aorp_drink_item',
                 'posts_per_page' => -1,
@@ -948,12 +947,10 @@ class AIO_Restaurant_Plugin {
                 }
                 echo '</tbody></table>';
                 echo '</div>';
-                echo $this->render_ingredient_legend();
                 wp_reset_postdata();
             }
         } else {
             foreach ( $terms as $term ) {
-                $this->ingredient_numbers = array();
                 $query = new WP_Query( array(
                     'post_type'      => 'aorp_drink_item',
                     'tax_query'      => array( array( 'taxonomy' => 'aorp_drink_category', 'field' => 'term_id', 'terms' => $term->term_id ) ),
@@ -988,11 +985,11 @@ class AIO_Restaurant_Plugin {
                     }
                     echo '</tbody></table>';
                     echo '</div>';
-                    echo $this->render_ingredient_legend();
                     wp_reset_postdata();
                 }
             }
         }
+        echo $this->render_ingredient_legend();
         echo '</div>';
         return ob_get_clean();
     }


### PR DESCRIPTION
## Summary
- remove duplicate ingredient legend displays
- show drink legend once after all categories

## Testing
- `php -l all-in-one-restaurant-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6872781b451c832988e571a0afc70682