### PR TITLE
Add AIO prefix and legend shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 All-In-One-WordPress-Restaurant-Plugin (AIWRP)
 
-Version: 1.5
+Version: 1.6
 Autor: Dein Name
 
 ## Funktionen
 
 - Digitale Speisekarte mit Suchfunktion
-- Getränkekarte inklusive Legende der Inhaltsstoffe je Kategorie
+- Getränkekarte mit optionaler Legende der Inhaltsstoffe per Shortcode
 - Dark‑Mode Umschalter mit auswählbaren Icon-Sets oder eigenen Symbolen
 - Import/Export mit Historie und Mustervorlagen (CSV, JSON, YAML)
 - Widgets und Shortcodes für Speisekarte, Getränkekarte, Lightswitcher und Leaflet-Karte
@@ -24,6 +24,7 @@ Autor: Dein Name
 
 - `[speisekarte]` – gibt die Speisekarte aus
 - `[getraenkekarte]` – zeigt die Getränkekarte
+- `[aio_ingredients_legend]` – zeigt die Legende der Inhaltsstoffe
 - `[restaurant_lightswitcher]` – Dark‑Mode Schalter
 - `[aio_leaflet_map]` – Leaflet-Karte
 - `[wp_grid_menu_overlay]` – Grid-Overlay

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: All-In-One WordPress Restaurant Plugin
 Description: Umfangreiches Speisekarten-Plugin mit Dark‑Mode, Suchfunktion und Import/Export.
-Version: 1.5
+Version: 1.6
 Author: stb-srv
 */
 
@@ -53,6 +53,7 @@ class AIO_Restaurant_Plugin {
         add_shortcode( 'speisekarte', array( $this, 'speisekarte_shortcode' ) );
         add_shortcode( 'restaurant_lightswitcher', array( $this, 'lightswitcher_shortcode' ) );
         add_shortcode( 'getraenkekarte', array( $this, 'getraenkekarte_shortcode' ) );
+        add_shortcode( 'aio_ingredients_legend', array( $this, 'ingredient_legend_shortcode' ) );
         add_action( 'admin_menu', array( $this, 'admin_menu' ) );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
         add_action( 'admin_post_aorp_export_csv', array( $this, 'export_csv' ) );
@@ -906,6 +907,10 @@ class AIO_Restaurant_Plugin {
         return '<div id="aorp-toggle" aria-label="Dark Mode umschalten" role="button" tabindex="0">' . $light . '</div>';
     }
 
+    public function ingredient_legend_shortcode() {
+        return $this->render_ingredient_legend();
+    }
+
     public function getraenkekarte_shortcode( $atts ) {
         $default = (int) get_option( 'aorp_menu_columns', 1 );
         $atts = shortcode_atts( array( 'columns' => $default, 'kategorien' => '' ), $atts, 'getraenkekarte' );
@@ -989,7 +994,6 @@ class AIO_Restaurant_Plugin {
                 }
             }
         }
-        echo $this->render_ingredient_legend();
         echo '</div>';
         return ob_get_clean();
     }
@@ -1029,18 +1033,18 @@ class AIO_Restaurant_Plugin {
     }
 
     public function admin_menu() {
-        add_menu_page( 'Speisekarte', 'Speisekarte', 'manage_options', 'aorp_manage', array( $this, 'manage_page' ), 'dashicons-list-view' );
-        add_submenu_page( 'aorp_manage', 'Getränke-Karte', 'Getränke-Karte', 'manage_options', 'aorp_drinks', array( $this, 'manage_drinks_page' ) );
-        add_submenu_page( 'aorp_manage', 'Import/Export', 'Import/Export', 'manage_options', 'aorp_export', array( $this, 'export_page' ) );
-        add_submenu_page( 'aorp_manage', 'Einstellungen', 'Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'settings_page' ) );
-        add_menu_page( 'Dark Mode', 'Dark Mode', 'manage_options', 'aorp_dark', array( $this, 'dark_page' ), 'dashicons-lightbulb' );
+        add_menu_page( 'AIO-Speisekarte', 'AIO-Speisekarte', 'manage_options', 'aorp_manage', array( $this, 'manage_page' ), 'dashicons-list-view' );
+        add_submenu_page( 'aorp_manage', 'AIO-Import/Export', 'AIO-Import/Export', 'manage_options', 'aorp_export', array( $this, 'export_page' ) );
+        add_submenu_page( 'aorp_manage', 'AIO-Einstellungen', 'AIO-Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'settings_page' ) );
+        add_menu_page( 'AIO-Getränke-Karte', 'AIO-Getränke-Karte', 'manage_options', 'aorp_drinks', array( $this, 'manage_drinks_page' ), 'dashicons-beer' );
+        add_menu_page( 'AIO-Dark Mode', 'AIO-Dark Mode', 'manage_options', 'aorp_dark', array( $this, 'dark_page' ), 'dashicons-lightbulb' );
         // Historie wird direkt auf der Import/Export Seite angezeigt
     }
 
     public function export_page() {
         ?>
         <div class="wrap">
-            <h1>Import/Export</h1>
+            <h1>AIO-Import/Export</h1>
             <h2>Mustervorlagen</h2>
             <ul>
                 <li><a href="<?php echo esc_url( plugin_dir_url( __FILE__ ) . 'samples/import-template.csv' ); ?>">CSV Vorlage</a></li>
@@ -1074,7 +1078,7 @@ class AIO_Restaurant_Plugin {
     public function settings_page() {
         ?>
         <div class="wrap">
-            <h1>Einstellungen</h1>
+            <h1>AIO-Einstellungen</h1>
             <form method="post" action="options.php">
                 <?php settings_fields( 'aorp_settings' ); ?>
                 <?php
@@ -1171,7 +1175,7 @@ class AIO_Restaurant_Plugin {
     public function dark_page() {
         ?>
         <div class="wrap">
-            <h1>Dark Mode</h1>
+            <h1>AIO-Dark Mode</h1>
             <p class="description">Wähle zunächst ein Icon-Set oder lade eigene Icons hoch.
             Nach deinen Anpassungen klicke auf „Änderungen speichern“.</p>
             <form method="post" action="options.php">
@@ -1295,7 +1299,7 @@ class AIO_Restaurant_Plugin {
         $current_ing  = $edit_ing ? get_post( $edit_ing ) : null;
         ?>
         <div class="wrap">
-            <h1>Speisekarte Verwaltung</h1>
+            <h1>AIO-Speisekarte Verwaltung</h1>
             <p class="description">Nutze den Shortcode <code>[speisekarte]</code> um die Speisekarte auf der Website einzubinden.</p>
             <?php $this->render_category_form( $categories, $current_cat ); ?>
             <?php $this->render_ingredient_form( $ingredients_posts, $current_ing ); ?>
@@ -1327,7 +1331,7 @@ class AIO_Restaurant_Plugin {
         $current_cat = $edit_cat ? get_term( $edit_cat, 'aorp_drink_category' ) : null;
         ?>
         <div class="wrap">
-            <h1>Getränke-Karte Verwaltung</h1>
+            <h1>AIO-Getränke-Karte Verwaltung</h1>
             <p class="description">Nutze den Shortcode <code>[getraenkekarte]</code> um die Getränke-Karte auf der Website einzubinden.</p>
             <?php $this->render_drink_category_form( $categories, $current_cat ); ?>
             <?php $this->render_drink_item_form( $items, $categories, $ingredients_list, $current ); ?>
@@ -2246,7 +2250,7 @@ class AIO_Restaurant_Plugin {
 
 
     public function history_page() {
-        echo '<div class="wrap"><h1>Import/Export Historie</h1>';
+        echo '<div class="wrap"><h1>AIO-Import/Export Historie</h1>';
         $this->render_history_table();
         echo '</div>';
     }

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -27,11 +27,11 @@ class WPGMO_Template_Manager {
 
     public function admin_menu() {
         if ( is_network_admin() ) {
-            $this->page_hook = add_menu_page( __('Grid-Vorlagen','aorp'), __('Grid-Vorlagen','aorp'), 'manage_network_options', 'wpgmo-templates', array( $this, 'render_page' ) );
-            $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('Grid-Inhalte','aorp'), __('Grid-Inhalte','aorp'), 'manage_network_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
+            $this->page_hook = add_menu_page( __('AIO-Grid-Vorlagen','aorp'), __('AIO-Grid-Vorlagen','aorp'), 'manage_network_options', 'wpgmo-templates', array( $this, 'render_page' ) );
+            $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('AIO-Grid-Inhalte','aorp'), __('AIO-Grid-Inhalte','aorp'), 'manage_network_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
         } else {
-            $this->page_hook = add_menu_page( __('Grid-Vorlagen','aorp'), __('Grid-Vorlagen','aorp'), 'manage_options', 'wpgmo-templates', array( $this, 'render_page' ) );
-            $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('Grid-Inhalte','aorp'), __('Grid-Inhalte','aorp'), 'manage_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
+            $this->page_hook = add_menu_page( __('AIO-Grid-Vorlagen','aorp'), __('AIO-Grid-Vorlagen','aorp'), 'manage_options', 'wpgmo-templates', array( $this, 'render_page' ) );
+            $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('AIO-Grid-Inhalte','aorp'), __('AIO-Grid-Inhalte','aorp'), 'manage_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
         }
     }
 
@@ -80,7 +80,7 @@ class WPGMO_Template_Manager {
         $default    = $is_network ? get_site_option( 'wpgmo_default_template_network', '' ) : get_option( 'wpgmo_default_template', '' );
         ?>
         <div class="wrap">
-            <h1><?php _e('Grid Templates','aorp'); ?></h1>
+            <h1><?php _e('AIO-Grid Templates','aorp'); ?></h1>
             <div id="wpgmo-template-manager" data-network="<?php echo $is_network ? 1 : 0; ?>" data-default="<?php echo esc_attr( $default ); ?>"></div>
         </div>
         <?php
@@ -107,7 +107,7 @@ class WPGMO_Template_Manager {
         }
         ?>
         <div class="wrap">
-            <h1><?php _e('Grid-Inhalte','aorp'); ?></h1>
+            <h1><?php _e('AIO-Grid-Inhalte','aorp'); ?></h1>
             <form method="post">
                 <?php wp_nonce_field( 'wpgmo_save_content' ); ?>
                 <?php foreach ( $templates as $slug => $tpl ) : ?>

--- a/includes/maps.php
+++ b/includes/maps.php
@@ -40,13 +40,13 @@ class AIO_Leaflet_Map {
     }
 
     public function admin_menu() {
-        add_menu_page( 'Karten', 'Karten', 'manage_options', 'aio_leaflet_map', array( $this, 'settings_page' ), 'dashicons-location-alt' );
+        add_menu_page( 'AIO-Karten', 'AIO-Karten', 'manage_options', 'aio_leaflet_map', array( $this, 'settings_page' ), 'dashicons-location-alt' );
     }
 
     public function settings_page() {
         ?>
         <div class="wrap">
-            <h1>Karten Einstellungen</h1>
+            <h1>AIO-Karten Einstellungen</h1>
             <div id="aio-leaflet-map-admin"></div>
             <form method="post" action="options.php">
                 <?php settings_fields( 'aio_leaflet_map' ); ?>


### PR DESCRIPTION
## Summary
- prefix all admin pages with `AIO-`
- move drink menu to its own admin page
- expose ingredient legend via shortcode
- update README for new shortcode and version

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l includes/maps.php`
- `php -l includes/class-wpgmo-template-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68727a1d80148329b0d070f2c93086c5