### PR TITLE
Add AJAX editing & sorting

### DIFF
--- a/admin/drink-list.php
+++ b/admin/drink-list.php
@@ -1,0 +1,52 @@
+<?php if ( $items ) : ?>
+    <h3>Alle Getränke</h3>
+    <input type="text" id="aorp-item-filter" placeholder="Suche" />
+    <p>
+        <button class="button aorp-select-all" data-target="#aorp-items-table tbody input[type=checkbox]">Alle auswählen</button>
+        <button class="button aorp-unselect-all" data-target="#aorp-items-table tbody input[type=checkbox]">Auswahl aufheben</button>
+    </p>
+    <table class="widefat" id="aorp-items-table">
+        <thead>
+            <tr>
+                <th></th>
+                <?php
+                    $cols = array(
+                        'title'       => 'Name',
+                        'description' => 'Beschreibung',
+                        'sizes'       => 'Größen/Preise',
+                        'ingredients' => 'Inhaltsstoffe',
+                        'category'    => 'Kategorie',
+                        'actions'     => 'Aktionen'
+                    );
+                    foreach ( $cols as $key => $label ) {
+                        if ( $key === 'actions' ) { echo '<th>' . esc_html( $label ) . '</th>'; continue; }
+                        $dir = ( $orderby === $key && $order === 'ASC' ) ? 'DESC' : 'ASC';
+                        $symbol = '';
+                        if ( $orderby === $key ) $symbol = $order === 'ASC' ? ' \u2191' : ' \u2193';
+                        $url = add_query_arg( array( 'orderby' => $key, 'order' => $dir ) );
+                        echo '<th class="aorp-sort"><a href="' . esc_url( $url ) . '">' . esc_html( $label ) . $symbol . '</a></th>';
+                    }
+                ?>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $items as $item ) :
+                $terms = get_the_terms( $item->ID, 'aorp_drink_category' );
+                $cat   = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0] : null;
+            ?>
+            <tr data-id="<?php echo esc_attr( $item->ID ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-sizes="<?php echo esc_attr( get_post_meta( $item->ID, '_aorp_drink_sizes', true ) ); ?>" data-ingredients="<?php echo esc_attr( get_post_meta( $item->ID, '_aorp_ingredients', true ) ); ?>" data-category="<?php echo esc_attr( $cat ? $cat->term_id : 0 ); ?>">
+                <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $item->ID ); ?>" /></td>
+                <td><?php echo esc_html( $item->post_title ); ?></td>
+                <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>
+                <td><?php echo nl2br( esc_html( get_post_meta( $item->ID, '_aorp_drink_sizes', true ) ) ); ?></td>
+                <td><?php echo esc_html( $this->get_ingredient_labels( get_post_meta( $item->ID, '_aorp_ingredients', true ) ) ); ?></td>
+                <td><?php echo $cat ? esc_html( $cat->name ) : ''; ?></td>
+                <td>
+                    <a href="#" class="aorp-edit-drink" data-id="<?php echo esc_attr( $item->ID ); ?>">Bearbeiten</a> |
+                    <a href="#" class="aorp-delete-drink" data-id="<?php echo esc_attr( $item->ID ); ?>" data-nonce="<?php echo wp_create_nonce( 'aorp_delete_drink_item_' . $item->ID ); ?>">Löschen</a>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>

--- a/admin/food-list.php
+++ b/admin/food-list.php
@@ -1,0 +1,59 @@
+<?php if ( $items ) : ?>
+    <h3>Alle Speisen</h3>
+    <input type="text" id="aorp-item-filter" placeholder="Suche" />
+    <p>
+        <button class="button aorp-select-all" data-target="#aorp-items-table tbody input[type=checkbox]">Alle auswählen</button>
+        <button class="button aorp-unselect-all" data-target="#aorp-items-table tbody input[type=checkbox]">Auswahl aufheben</button>
+    </p>
+    <table class="widefat" id="aorp-items-table">
+        <thead>
+            <tr>
+                <th></th>
+                <?php
+                    $cols = array(
+                        'title'       => 'Name',
+                        'description' => 'Beschreibung',
+                        'price'       => 'Preis',
+                        'number'      => 'Nummer',
+                        'ingredients' => 'Inhaltsstoffe',
+                        'category'    => 'Kategorie',
+                        'actions'     => 'Aktionen'
+                    );
+                    foreach ( $cols as $key => $label ) {
+                        if ( $key === 'actions' ) {
+                            echo '<th>' . esc_html( $label ) . '</th>';
+                            continue;
+                        }
+                        $dir = ( $orderby === $key && $order === 'ASC' ) ? 'DESC' : 'ASC';
+                        $symbol = '';
+                        if ( $orderby === $key ) {
+                            $symbol = $order === 'ASC' ? ' \u2191' : ' \u2193';
+                        }
+                        $url = add_query_arg( array( 'orderby' => $key, 'order' => $dir ) );
+                        echo '<th class="aorp-sort"><a href="' . esc_url( $url ) . '">' . esc_html( $label ) . $symbol . '</a></th>';
+                    }
+                ?>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $items as $item ) :
+                $terms = get_the_terms( $item->ID, 'aorp_menu_category' );
+                $cat   = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0] : null;
+            ?>
+            <tr data-id="<?php echo esc_attr( $item->ID ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-price="<?php echo esc_attr( get_post_meta( $item->ID, '_aorp_price', true ) ); ?>" data-number="<?php echo esc_attr( get_post_meta( $item->ID, '_aorp_number', true ) ); ?>" data-ingredients="<?php echo esc_attr( get_post_meta( $item->ID, '_aorp_ingredients', true ) ); ?>" data-category="<?php echo esc_attr( $cat ? $cat->term_id : 0 ); ?>">
+                <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $item->ID ); ?>" /></td>
+                <td><?php echo esc_html( $item->post_title ); ?></td>
+                <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>
+                <td><?php echo esc_html( $this->format_price( get_post_meta( $item->ID, '_aorp_price', true ) ) ); ?></td>
+                <td><?php echo esc_html( get_post_meta( $item->ID, '_aorp_number', true ) ); ?></td>
+                <td><?php echo esc_html( $this->get_ingredient_labels( get_post_meta( $item->ID, '_aorp_ingredients', true ) ) ); ?></td>
+                <td><?php echo $cat ? esc_html( $cat->name ) : ''; ?></td>
+                <td>
+                    <a href="#" class="aorp-edit" data-id="<?php echo esc_attr( $item->ID ); ?>">Bearbeiten</a> |
+                    <a href="#" class="aorp-delete" data-id="<?php echo esc_attr( $item->ID ); ?>" data-nonce="<?php echo wp_create_nonce( 'aorp_delete_item_' . $item->ID ); ?>">Löschen</a>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -20,3 +20,31 @@
     font-size: 20px;
 }
 
+.aorp-spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid #ccc;
+    border-top-color: #000;
+    border-radius: 50%;
+    animation: aorp-spin 1s linear infinite;
+    margin-left: 5px;
+}
+
+@keyframes aorp-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.aorp-toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 3px;
+    z-index: 9999;
+}
+

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,89 @@
+jQuery(function($){
+    function showToast(text){
+        var toast = $('<div class="aorp-toast" />').text(text);
+        $('body').append(toast);
+        setTimeout(function(){ toast.fadeOut(400,function(){ $(this).remove(); }); },3000);
+    }
+    function ajaxForm(form, action){
+        var spinner = $('<span class="aorp-spinner is-active" />');
+        form.find('button[type=submit]').after(spinner);
+        $.post(aorp_admin.ajax_url, form.serialize()+"&action="+action, function(resp){
+            spinner.remove();
+            if(resp.success){
+                if(resp.data.row){
+                    if(form.hasClass('aorp-add-form')){
+                        $('#aorp-items-table tbody').append(resp.data.row);
+                        form[0].reset();
+                    }else{
+                        form.closest('tr').replaceWith(resp.data.row);
+                    }
+                }
+                showToast('Gespeichert');
+            }else if(resp.data && resp.data.message){
+                alert(resp.data.message);
+            }
+        });
+    }
+
+    $(document).on('submit','.aorp-add-form',function(e){
+        e.preventDefault();
+        ajaxForm($(this), $(this).data('action'));
+    });
+
+    $(document).on('click','.aorp-edit',function(e){
+        e.preventDefault();
+        var row = $(this).closest('tr');
+        if(row.next().hasClass('aorp-edit-row')) return;
+        var data = row.data();
+        var cols = $('<tr class="aorp-edit-row"><td colspan="8"></td></tr>');
+        var form = $('<form class="aorp-inline-edit" />').append(
+            '<input type="hidden" name="action" value="aorp_update_item" />'+
+            '<input type="hidden" name="nonce" value="'+aorp_admin.nonce_edit+'" />'+
+            '<input type="hidden" name="item_id" value="'+data.id+'" />'+
+            '<p><input type="text" name="item_number" value="'+data.number+'" placeholder="Nummer" /></p>'+
+            '<p><input type="text" name="item_title" value="'+data.title+'" required /></p>'+
+            '<p><textarea name="item_description">'+data.description+'</textarea></p>'+
+            '<p><input type="text" name="item_price" value="'+data.price+'" /></p>'+
+            '<button type="submit" class="button button-primary">Speichern</button> '+
+            '<button class="button aorp-cancel">Abbrechen</button>'
+        );
+        cols.find('td').append(form);
+        row.after(cols); row.hide();
+    });
+
+    $(document).on('click','.aorp-cancel',function(e){
+        e.preventDefault();
+        var editRow = $(this).closest('tr.aorp-edit-row');
+        editRow.prev('tr').show();
+        editRow.remove();
+    });
+
+    $(document).on('submit','.aorp-inline-edit',function(e){
+        e.preventDefault();
+        ajaxForm($(this), 'aorp_update_item');
+    });
+
+    $(document).on('click','.aorp-delete',function(e){
+        e.preventDefault();
+        var id = $(this).data('id');
+        var nonce = $(this).data('nonce');
+        var row = $(this).closest('tr');
+        $.post(aorp_admin.ajax_url,{action:'aorp_delete_item',item_id:id,nonce:nonce},function(resp){
+            if(resp.success){
+                row.hide();
+                var undo = $('<div class="aorp-toast">Eintrag gelöscht. <a href="#">Rückgängig</a></div>');
+                $('body').append(undo);
+                undo.find('a').on('click',function(ev){
+                    ev.preventDefault();
+                    $.post(aorp_admin.ajax_url,{action:'aorp_undo_delete_item',item_id:id,nonce:resp.data.undo_nonce},function(r){
+                        if(r.success&&r.data.row){
+                            row.replaceWith(r.data.row);
+                        }
+                        undo.remove();
+                    });
+                });
+                setTimeout(function(){ undo.fadeOut(400,function(){ $(this).remove(); }); },5000);
+            }
+        });
+    });
+});

--- a/includes/ajax-handler.php
+++ b/includes/ajax-handler.php
@@ -1,0 +1,294 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AORP_Ajax_Handler {
+    public static function init() {
+        $handler = new self();
+        add_action( 'wp_ajax_aorp_add_item', array( $handler, 'add_item' ) );
+        add_action( 'wp_ajax_aorp_update_item', array( $handler, 'update_item' ) );
+        add_action( 'wp_ajax_aorp_delete_item', array( $handler, 'delete_item' ) );
+        add_action( 'wp_ajax_aorp_undo_delete_item', array( $handler, 'undo_delete_item' ) );
+
+        add_action( 'wp_ajax_aorp_add_drink_item', array( $handler, 'add_drink_item' ) );
+        add_action( 'wp_ajax_aorp_update_drink_item', array( $handler, 'update_drink_item' ) );
+        add_action( 'wp_ajax_aorp_delete_drink_item', array( $handler, 'delete_drink_item' ) );
+        add_action( 'wp_ajax_aorp_undo_delete_drink_item', array( $handler, 'undo_delete_drink_item' ) );
+    }
+
+    private function check_nonce( $action ) {
+        $nonce = isset( $_POST['nonce'] ) ? $_POST['nonce'] : '';
+        if ( ! wp_verify_nonce( $nonce, $action ) ) {
+            wp_send_json_error( array( 'message' => 'Ungültige Anfrage.' ) );
+        }
+    }
+
+    private function format_price( $price ) {
+        $price = trim( (string) $price );
+        if ( '' === $price ) {
+            return '';
+        }
+        if ( strpos( $price, '€' ) === false ) {
+            $price .= ' €';
+        }
+        return $price;
+    }
+
+    private function get_ingredient_labels( $codes ) {
+        $codes = array_filter( array_map( 'trim', explode( ',', $codes ) ) );
+        if ( empty( $codes ) ) {
+            return '';
+        }
+        $lookup = array();
+        $ings = get_posts( array( 'post_type' => 'aorp_ingredient', 'numberposts' => -1 ) );
+        foreach ( $ings as $ing ) {
+            $code = get_post_meta( $ing->ID, '_aorp_ing_code', true );
+            $lookup[ $code ] = $ing->post_title;
+        }
+        $labels = array();
+        foreach ( $codes as $code ) {
+            if ( isset( $lookup[ $code ] ) ) {
+                $labels[] = $lookup[ $code ] . ' (' . $code . ')';
+            } else {
+                $labels[] = $code;
+            }
+        }
+        return implode( ', ', $labels );
+    }
+
+    private function food_row_html( $id ) {
+        $item = get_post( $id );
+        if ( ! $item ) {
+            return '';
+        }
+        $price = get_post_meta( $id, '_aorp_price', true );
+        $number = get_post_meta( $id, '_aorp_number', true );
+        $ingredients = get_post_meta( $id, '_aorp_ingredients', true );
+        $terms = get_the_terms( $id, 'aorp_menu_category' );
+        $cat = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->name : '';
+        $cat_id = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->term_id : 0;
+        ob_start();
+        ?>
+        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-price="<?php echo esc_attr( $price ); ?>" data-number="<?php echo esc_attr( $number ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>">
+            <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $id ); ?>" /></td>
+            <td><?php echo esc_html( $item->post_title ); ?></td>
+            <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>
+            <td><?php echo esc_html( $this->format_price( $price ) ); ?></td>
+            <td><?php echo esc_html( $number ); ?></td>
+            <td><?php echo esc_html( $this->get_ingredient_labels( $ingredients ) ); ?></td>
+            <td><?php echo esc_html( $cat ); ?></td>
+            <td>
+                <a href="#" class="aorp-edit" data-id="<?php echo esc_attr( $id ); ?>"><?php _e( 'Bearbeiten', 'aorp' ); ?></a> |
+                <a href="#" class="aorp-delete" data-id="<?php echo esc_attr( $id ); ?>" data-nonce="<?php echo wp_create_nonce( 'aorp_delete_item_' . $id ); ?>"><?php _e( 'Löschen', 'aorp' ); ?></a>
+            </td>
+        </tr>
+        <?php
+        return ob_get_clean();
+    }
+
+    private function drink_row_html( $id ) {
+        $item = get_post( $id );
+        if ( ! $item ) {
+            return '';
+        }
+        $sizes = nl2br( esc_html( get_post_meta( $id, '_aorp_drink_sizes', true ) ) );
+        $ingredients = get_post_meta( $id, '_aorp_ingredients', true );
+        $terms = get_the_terms( $id, 'aorp_drink_category' );
+        $cat = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->name : '';
+        $cat_id = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->term_id : 0;
+        ob_start();
+        ?>
+        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-sizes="<?php echo esc_attr( get_post_meta( $id, '_aorp_drink_sizes', true ) ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>">
+            <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $id ); ?>" /></td>
+            <td><?php echo esc_html( $item->post_title ); ?></td>
+            <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>
+            <td><?php echo $sizes; ?></td>
+            <td><?php echo esc_html( $this->get_ingredient_labels( $ingredients ) ); ?></td>
+            <td><?php echo esc_html( $cat ); ?></td>
+            <td>
+                <a href="#" class="aorp-edit-drink" data-id="<?php echo esc_attr( $id ); ?>"><?php _e( 'Bearbeiten', 'aorp' ); ?></a> |
+                <a href="#" class="aorp-delete-drink" data-id="<?php echo esc_attr( $id ); ?>" data-nonce="<?php echo wp_create_nonce( 'aorp_delete_drink_item_' . $id ); ?>"><?php _e( 'Löschen', 'aorp' ); ?></a>
+            </td>
+        </tr>
+        <?php
+        return ob_get_clean();
+    }
+
+    public function add_item() {
+        $this->check_nonce( 'aorp_add_item' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $post_id = wp_insert_post( array(
+            'post_type'   => 'aorp_menu_item',
+            'post_status' => 'publish',
+            'post_title'  => sanitize_text_field( $_POST['item_title'] ),
+            'post_content'=> sanitize_textarea_field( $_POST['item_description'] )
+        ) );
+        if ( $post_id ) {
+            if ( ! empty( $_POST['item_category'] ) ) {
+                wp_set_object_terms( $post_id, intval( $_POST['item_category'] ), 'aorp_menu_category' );
+            }
+            if ( isset( $_POST['item_price'] ) ) {
+                update_post_meta( $post_id, '_aorp_price', sanitize_text_field( $_POST['item_price'] ) );
+            }
+            if ( isset( $_POST['item_number'] ) ) {
+                update_post_meta( $post_id, '_aorp_number', sanitize_text_field( $_POST['item_number'] ) );
+            }
+            if ( ! empty( $_POST['item_image_id'] ) ) {
+                set_post_thumbnail( $post_id, intval( $_POST['item_image_id'] ) );
+            }
+            if ( isset( $_POST['item_ingredients'] ) ) {
+                update_post_meta( $post_id, '_aorp_ingredients', sanitize_textarea_field( $_POST['item_ingredients'] ) );
+            }
+            wp_send_json_success( array( 'row' => $this->food_row_html( $post_id ) ) );
+        }
+        wp_send_json_error();
+    }
+
+    public function update_item() {
+        $this->check_nonce( 'aorp_edit_item' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $post_id = intval( $_POST['item_id'] );
+        wp_update_post( array(
+            'ID'           => $post_id,
+            'post_title'   => sanitize_text_field( $_POST['item_title'] ),
+            'post_content' => sanitize_textarea_field( $_POST['item_description'] )
+        ) );
+        if ( ! empty( $_POST['item_category'] ) ) {
+            wp_set_object_terms( $post_id, intval( $_POST['item_category'] ), 'aorp_menu_category' );
+        } else {
+            wp_set_object_terms( $post_id, array(), 'aorp_menu_category' );
+        }
+        if ( isset( $_POST['item_price'] ) ) {
+            update_post_meta( $post_id, '_aorp_price', sanitize_text_field( $_POST['item_price'] ) );
+        }
+        if ( isset( $_POST['item_number'] ) ) {
+            update_post_meta( $post_id, '_aorp_number', sanitize_text_field( $_POST['item_number'] ) );
+        }
+        if ( ! empty( $_POST['item_image_id'] ) ) {
+            set_post_thumbnail( $post_id, intval( $_POST['item_image_id'] ) );
+        }
+        if ( isset( $_POST['item_ingredients'] ) ) {
+            update_post_meta( $post_id, '_aorp_ingredients', sanitize_textarea_field( $_POST['item_ingredients'] ) );
+        }
+        wp_send_json_success( array( 'row' => $this->food_row_html( $post_id ) ) );
+    }
+
+    public function delete_item() {
+        $id = intval( $_POST['item_id'] );
+        $this->check_nonce( 'aorp_delete_item_' . $id );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        wp_trash_post( $id );
+        wp_send_json_success( array( 'undo_nonce' => wp_create_nonce( 'aorp_undo_delete_item_' . $id ) ) );
+    }
+
+    public function undo_delete_item() {
+        $id = intval( $_POST['item_id'] );
+        $this->check_nonce( 'aorp_undo_delete_item_' . $id );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        wp_untrash_post( $id );
+        wp_send_json_success( array( 'row' => $this->food_row_html( $id ) ) );
+    }
+
+    public function add_drink_item() {
+        $this->check_nonce( 'aorp_add_drink_item' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $title = sanitize_text_field( $_POST['item_title'] );
+        $existing = get_page_by_title( $title, OBJECT, 'aorp_drink_item' );
+        if ( $existing ) {
+            wp_send_json_error( array( 'message' => 'Getränk existiert bereits.' ) );
+        }
+        $post_id = wp_insert_post( array(
+            'post_type'   => 'aorp_drink_item',
+            'post_status' => 'publish',
+            'post_title'  => $title,
+            'post_content'=> sanitize_textarea_field( $_POST['item_description'] )
+        ) );
+        if ( $post_id ) {
+            if ( ! empty( $_POST['item_category'] ) ) {
+                wp_set_object_terms( $post_id, intval( $_POST['item_category'] ), 'aorp_drink_category' );
+            }
+            if ( isset( $_POST['item_sizes'] ) && is_array( $_POST['item_sizes'] ) ) {
+                $lines = array();
+                foreach ( $_POST['item_sizes'] as $vol => $price ) {
+                    $price = trim( $price );
+                    if ( $price !== '' ) {
+                        $lines[] = $vol . '=' . $price;
+                    }
+                }
+                update_post_meta( $post_id, '_aorp_drink_sizes', implode( "\n", $lines ) );
+            }
+            if ( isset( $_POST['item_ingredients'] ) ) {
+                update_post_meta( $post_id, '_aorp_ingredients', sanitize_textarea_field( $_POST['item_ingredients'] ) );
+            }
+            wp_send_json_success( array( 'row' => $this->drink_row_html( $post_id ) ) );
+        }
+        wp_send_json_error();
+    }
+
+    public function update_drink_item() {
+        $this->check_nonce( 'aorp_edit_drink_item' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        $post_id = intval( $_POST['item_id'] );
+        $title   = sanitize_text_field( $_POST['item_title'] );
+        $existing = get_page_by_title( $title, OBJECT, 'aorp_drink_item' );
+        if ( $existing && intval( $existing->ID ) !== $post_id ) {
+            wp_send_json_error( array( 'message' => 'Getränk existiert bereits.' ) );
+        }
+        wp_update_post( array(
+            'ID'           => $post_id,
+            'post_title'   => $title,
+            'post_content' => sanitize_textarea_field( $_POST['item_description'] )
+        ) );
+        if ( ! empty( $_POST['item_category'] ) ) {
+            wp_set_object_terms( $post_id, intval( $_POST['item_category'] ), 'aorp_drink_category' );
+        }
+        if ( isset( $_POST['item_sizes'] ) && is_array( $_POST['item_sizes'] ) ) {
+            $lines = array();
+            foreach ( $_POST['item_sizes'] as $vol => $price ) {
+                $price = trim( $price );
+                if ( $price !== '' ) {
+                    $lines[] = $vol . '=' . $price;
+                }
+            }
+            update_post_meta( $post_id, '_aorp_drink_sizes', implode( "\n", $lines ) );
+        }
+        if ( isset( $_POST['item_ingredients'] ) ) {
+            update_post_meta( $post_id, '_aorp_ingredients', sanitize_textarea_field( $_POST['item_ingredients'] ) );
+        }
+        wp_send_json_success( array( 'row' => $this->drink_row_html( $post_id ) ) );
+    }
+
+    public function delete_drink_item() {
+        $id = intval( $_POST['item_id'] );
+        $this->check_nonce( 'aorp_delete_drink_item_' . $id );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        wp_trash_post( $id );
+        wp_send_json_success( array( 'undo_nonce' => wp_create_nonce( 'aorp_undo_delete_drink_item_' . $id ) ) );
+    }
+
+    public function undo_delete_drink_item() {
+        $id = intval( $_POST['item_id'] );
+        $this->check_nonce( 'aorp_undo_delete_drink_item_' . $id );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error();
+        }
+        wp_untrash_post( $id );
+        wp_send_json_success( array( 'row' => $this->drink_row_html( $id ) ) );
+    }
+}
+AORP_Ajax_Handler::init();


### PR DESCRIPTION
## Summary
- enable AJAX CRUD operations through new `AORP_Ajax_Handler`
- include new admin templates for foods and drinks
- support sorting via GET parameters and highlight active sort
- add JS for inline editing, undo and toast messages
- update admin styling for spinner and toast notifications

## Testing
- `php -l includes/ajax-handler.php`
- `php -l all-in-one-restaurant-plugin.php`
- `php -l admin/food-list.php`
- `php -l admin/drink-list.php`

------
https://chatgpt.com/codex/tasks/task_e_68727f91662c8329a6b3c452868af961