### PR TITLE
Fix widgets syntax error

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -23,6 +23,7 @@ class AORP_Menu_Widget extends WP_Widget {
         echo do_shortcode('[speisekarte]');
         echo $args['after_widget'];
     }
+}
 /**
  * Widget providing a dark mode switcher.
  */


### PR DESCRIPTION
## Summary
- add missing closing brace to widget file

## Testing
- `php -l`

------
https://chatgpt.com/codex/tasks/task_e_6872aa7048c8832994ef057311d0a2a9