### PR TITLE
Enhance menus with search & responsive columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Dieses Plugin bietet eine moderne Verwaltung von Speise- und Getränkekarten fü
 
 ## Shortcodes
 
-- `[speisekarte]` – zeigt alle angelegten Speisen
-- `[getraenkekarte]` – zeigt alle angelegten Getränke
+- `[speisekarte columns="2"]` – zeigt alle Speisen, optional 2 oder 3 Spalten
+- `[getraenkekarte columns="2"]` – zeigt alle Getränke, optional 2 oder 3 Spalten
 - `[restaurant_lightswitcher]` – Button zum Umschalten des Darkmode
 
 ## Entwicklerhinweise

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -22,14 +22,37 @@ class AORP_Admin_Pages {
      */
     public function menu(): void {
         add_menu_page(
-            'Speisekarte',
-            'Speisekarte',
+            'AIO-Speisekarte',
+            'AIO-Speisekarte',
             'manage_options',
             'aorp_manage',
             array( $this, 'render_page' ),
             'dashicons-carrot',
             26
         );
+
+        add_submenu_page(
+            'aorp_manage',
+            'AIO-Speisekarte',
+            'AIO-Speisekarte',
+            'manage_options',
+            'aorp_manage',
+            array( $this, 'render_page' )
+        );
+
+        add_submenu_page(
+            'aorp_manage',
+            'AIO-Getraenkekarte',
+            'AIO-Getraenkekarte',
+            'manage_options',
+            'aorp_manage_drinks',
+            array( $this, 'render_drink_page' )
+        );
+    }
+
+    public function render_drink_page(): void {
+        $_GET['tab'] = 'drinks';
+        $this->render_page();
     }
 
     /**

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -20,13 +20,25 @@ class AORP_Shortcodes {
     /**
      * Render food list.
      */
-    public function render_foods(): string {
+    public function render_foods( array $atts = array() ): string {
+        $atts = shortcode_atts( array(
+            'columns' => 2,
+        ), $atts, 'speisekarte' );
+
+        $columns_class = '';
+        $col = intval( $atts['columns'] );
+        if ( in_array( $col, array( 2, 3 ), true ) ) {
+            $columns_class = ' columns-' . $col;
+        }
+
         $categories = get_terms( 'aorp_menu_category', array( 'hide_empty' => false ) );
         if ( empty( $categories ) ) {
             $categories = array();
         }
         ob_start();
-        echo '<div class="aorp-menu">';
+        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="Suche..." /><button id="aorp-close-cats" class="aorp-close-cats">Kategorien schließen</button><div id="aorp-search-results"></div></div>';
+        echo '<p class="aorp-note">Bitte klicken Sie auf die Kategorien, um die Speisen zu sehen.</p>';
+        echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
             echo '<div class="aorp-category">' . esc_html( $cat->name ) . '</div>';
             echo '<div class="aorp-items">';
@@ -66,13 +78,25 @@ class AORP_Shortcodes {
     /**
      * Render drink list.
      */
-    public function render_drinks(): string {
+    public function render_drinks( array $atts = array() ): string {
+        $atts = shortcode_atts( array(
+            'columns' => 2,
+        ), $atts, 'getraenkekarte' );
+
+        $columns_class = '';
+        $col = intval( $atts['columns'] );
+        if ( in_array( $col, array( 2, 3 ), true ) ) {
+            $columns_class = ' columns-' . $col;
+        }
+
         $categories = get_terms( 'aorp_drink_category', array( 'hide_empty' => false ) );
         if ( empty( $categories ) ) {
             $categories = array();
         }
         ob_start();
-        echo '<div class="aorp-menu">';
+        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="Suche..." /><button id="aorp-close-cats" class="aorp-close-cats">Kategorien schließen</button><div id="aorp-search-results"></div></div>';
+        echo '<p class="aorp-note">Bitte klicken Sie auf die Kategorien, um die Speisen zu sehen.</p>';
+        echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
             echo '<div class="aorp-category">' . esc_html( $cat->name ) . '</div>';
             echo '<div class="aorp-items">';


### PR DESCRIPTION
## Summary
- allow selecting column layout and include a search box for menu shortcodes
- rename admin menu to **AIO-Speisekarte** with a subpage **AIO-Getraenkekarte**
- document new shortcode options

## Testing
- `php -l includes/class-aorp-shortcodes.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l all-in-one-restaurant-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6873bb05605c8329a434a607f07e2c43