### PR TITLE
Add layout controls to settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Dieses Plugin bietet eine moderne Verwaltung von Speise- und Getränkekarten fü
 
 ## Shortcodes
 
-- `[speisekarte columns="2"]` – zeigt alle Speisen, optional 2 oder 3 Spalten
-- `[getraenkekarte columns="2"]` – zeigt alle Getränke, optional 2 oder 3 Spalten
+- `[speisekarte]` – zeigt alle angelegten Speisen
+- `[getraenkekarte]` – zeigt alle angelegten Getränke
 - `[restaurant_lightswitcher]` – Button zum Umschalten des Darkmode
+
+Die Anzahl der Spalten für Speise- und Getränkekarte lässt sich nun in den Plugin-Einstellungen festlegen.
 
 ## Entwicklerhinweise
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,9 @@ Important hooks register post types, taxonomies and enqueue scripts. The most
 visible shortcodes are `[speisekarte]`, `[getraenkekarte]`,
 `[aio_ingredients_legend]`, `[restaurant_lightswitcher]` and `[aio_leaflet_map]`.
 
+The number of columns displayed by the food and drink menus can be configured
+from the plugin settings page in the WordPress administration.
+
 ## Translations and Samples
 
 Translations are managed with `languages/aorp.pot`. Example import files for CSV,

--- a/includes/class-aorp-settings.php
+++ b/includes/class-aorp-settings.php
@@ -28,6 +28,8 @@ class AORP_Settings {
 
         add_settings_section( 'aorp_general', __( 'Allgemein', 'aorp' ), '__return_false', 'aorp_settings' );
         add_settings_field( 'license_key', __( 'Lizenzschlüssel', 'aorp' ), array( $this, 'field_license_key' ), 'aorp_settings', 'aorp_general' );
+        add_settings_field( 'food_columns', __( 'Spalten Speisekarte', 'aorp' ), array( $this, 'field_food_columns' ), 'aorp_settings', 'aorp_general' );
+        add_settings_field( 'drink_columns', __( 'Spalten Getränkekarte', 'aorp' ), array( $this, 'field_drink_columns' ), 'aorp_settings', 'aorp_general' );
     }
 
     /**
@@ -37,6 +39,32 @@ class AORP_Settings {
         $options = get_option( 'aorp_options', array() );
         $value   = isset( $options['license_key'] ) ? esc_attr( $options['license_key'] ) : '';
         echo '<input type="text" name="aorp_options[license_key]" value="' . $value . '" class="regular-text" />';
+    }
+
+    /**
+     * Render food column select.
+     */
+    public function field_food_columns(): void {
+        $options = get_option( 'aorp_options', array() );
+        $value   = isset( $options['food_columns'] ) ? (int) $options['food_columns'] : 2;
+        echo '<select name="aorp_options[food_columns]">';
+        foreach ( array( 2, 3 ) as $col ) {
+            printf( '<option value="%1$d" %2$s>%1$d</option>', $col, selected( $value, $col, false ) );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * Render drink column select.
+     */
+    public function field_drink_columns(): void {
+        $options = get_option( 'aorp_options', array() );
+        $value   = isset( $options['drink_columns'] ) ? (int) $options['drink_columns'] : 2;
+        echo '<select name="aorp_options[drink_columns]">';
+        foreach ( array( 2, 3 ) as $col ) {
+            printf( '<option value="%1$d" %2$s>%1$d</option>', $col, selected( $value, $col, false ) );
+        }
+        echo '</select>';
     }
 
     /**

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -21,12 +21,9 @@ class AORP_Shortcodes {
      * Render food list.
      */
     public function render_foods( array $atts = array() ): string {
-        $atts = shortcode_atts( array(
-            'columns' => 2,
-        ), $atts, 'speisekarte' );
-
+        $options = get_option( 'aorp_options', array() );
+        $col     = isset( $options['food_columns'] ) ? intval( $options['food_columns'] ) : 2;
         $columns_class = '';
-        $col = intval( $atts['columns'] );
         if ( in_array( $col, array( 2, 3 ), true ) ) {
             $columns_class = ' columns-' . $col;
         }
@@ -79,12 +76,9 @@ class AORP_Shortcodes {
      * Render drink list.
      */
     public function render_drinks( array $atts = array() ): string {
-        $atts = shortcode_atts( array(
-            'columns' => 2,
-        ), $atts, 'getraenkekarte' );
-
+        $options = get_option( 'aorp_options', array() );
+        $col     = isset( $options['drink_columns'] ) ? intval( $options['drink_columns'] ) : 2;
         $columns_class = '';
-        $col = intval( $atts['columns'] );
         if ( in_array( $col, array( 2, 3 ), true ) ) {
             $columns_class = ' columns-' . $col;
         }


### PR DESCRIPTION
## Summary
- make layout configurable in admin
- use settings for shortcode layout columns
- document new layout controls

## Testing
- `php -l includes/class-aorp-settings.php`
- `php -l includes/class-aorp-shortcodes.php`
- `php -l all-in-one-restaurant-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_6873c220fa508329be21ff2de9883bf3