### PR TITLE
Add AIO-Restaurant menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dieses Plugin bietet eine moderne Verwaltung von Speise- und Getränkekarten fü
 
 1. Plugin in den Ordner `wp-content/plugins` kopieren
 2. Im Backend aktivieren
+3. Die Administration erfolgt über den neuen Menüpunkt "AIO-Restaurant"
 
 ## Shortcodes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ visible shortcodes are `[speisekarte]`, `[getraenkekarte]`,
 `[aio_ingredients_legend]`, `[restaurant_lightswitcher]` and `[aio_leaflet_map]`.
 
 The number of columns displayed by the food and drink menus can be configured
-from the plugin settings page in the WordPress administration.
+from the plugin settings page located under the "AIO-Restaurant" menu in the WordPress administration.
 
 ## Translations and Samples
 

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -22,8 +22,8 @@ class AORP_Admin_Pages {
      */
     public function menu(): void {
         add_menu_page(
-            'AIO-Speisekarte',
-            'AIO-Speisekarte',
+            'AIO-Restaurant',
+            'AIO-Restaurant',
             'manage_options',
             'aorp_manage',
             array( $this, 'render_page' ),
@@ -33,8 +33,8 @@ class AORP_Admin_Pages {
 
         add_submenu_page(
             'aorp_manage',
-            'AIO-Speisekarte',
-            'AIO-Speisekarte',
+            'Speisekarte',
+            'Speisekarte',
             'manage_options',
             'aorp_manage',
             array( $this, 'render_page' )
@@ -42,12 +42,13 @@ class AORP_Admin_Pages {
 
         add_submenu_page(
             'aorp_manage',
-            'AIO-Getraenkekarte',
-            'AIO-Getraenkekarte',
+            'Getränkekarte',
+            'Getränkekarte',
             'manage_options',
             'aorp_manage_drinks',
             array( $this, 'render_drink_page' )
         );
+
     }
 
     public function render_drink_page(): void {

--- a/includes/class-aorp-settings.php
+++ b/includes/class-aorp-settings.php
@@ -17,7 +17,7 @@ class AORP_Settings {
      * Add settings page.
      */
     public function add_settings_page(): void {
-        add_options_page( 'Restaurant Einstellungen', 'Restaurant', 'manage_options', 'aorp_settings', array( $this, 'render_settings_page' ) );
+        add_submenu_page( 'aorp_manage', 'Einstellungen', 'Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'render_settings_page' ) );
     }
 
     /**


### PR DESCRIPTION
## Summary
- rename admin menu to **AIO-Restaurant**
- move plugin settings under this new menu
- update documentation for new menu location

## Testing
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-aorp-settings.php`
- `find includes -name '*.php' -print0 | xargs -0 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6873c65ae0c083298a43e0356abf1844