### PR TITLE
Add image upload & dark mode, restructure admin menu

### DIFF
--- a/admin/item-list.php
+++ b/admin/item-list.php
@@ -49,6 +49,8 @@
                     'description' => $item->post_content,
                     'ingredients' => get_post_meta( $item->ID, '_aorp_ingredients', true ),
                     'category'    => $cat ? $cat->term_id : 0,
+                    'imageid'     => get_post_thumbnail_id( $item->ID ),
+                    'imageurl'    => get_post_thumbnail_id( $item->ID ) ? wp_get_attachment_image_url( get_post_thumbnail_id( $item->ID ), 'thumbnail' ) : '',
                 );
                 if ( $mode === 'drink' ) {
                     $data['sizes'] = get_post_meta( $item->ID, '_aorp_drink_sizes', true );

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -87,6 +87,11 @@ add_action( 'plugins_loaded', 'aorp_init_plugin' );
 function aorp_enqueue_assets(): void {
     wp_enqueue_style( 'aorp-frontend', plugins_url( 'assets/style.css', __FILE__ ), array(), '1.0' );
     wp_enqueue_script( 'aorp-frontend', plugins_url( 'assets/js/frontend/script.js', __FILE__ ), array( 'jquery' ), '1.0', true );
+    wp_localize_script( 'aorp-frontend', 'aorp_ajax', array(
+        'url'        => admin_url( 'admin-ajax.php' ),
+        'icon_light' => '☀️',
+        'icon_dark'  => '🌙',
+    ) );
 }
 add_action( 'wp_enqueue_scripts', 'aorp_enqueue_assets' );
 
@@ -94,9 +99,18 @@ function aorp_admin_assets(): void {
     wp_enqueue_style( 'aorp-admin', plugins_url( 'assets/css/admin.css', __FILE__ ), array(), '1.0' );
     wp_enqueue_script( 'aorp-admin-filters', plugins_url( 'assets/js/admin/filters.js', __FILE__ ), array( 'jquery' ), '1.0', true );
     wp_enqueue_script( 'aorp-admin-items', plugins_url( 'assets/js/admin/item-management.js', __FILE__ ), array( 'jquery' ), '1.0', true );
+    wp_enqueue_media();
     wp_localize_script( 'aorp-admin-items', 'aorp_admin', array(
         'ajax_url'   => admin_url( 'admin-ajax.php' ),
         'nonce_edit' => wp_create_nonce( 'aorp_edit_item' ),
     ) );
 }
 add_action( 'admin_enqueue_scripts', 'aorp_admin_assets' );
+
+function aorp_toggle_dark_callback() {
+    $mode = ( isset( $_POST['mode'] ) && 'on' === $_POST['mode'] ) ? 'on' : 'off';
+    setcookie( 'aorp_dark_mode', $mode, time() + YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+    wp_die();
+}
+add_action( 'wp_ajax_aorp_toggle_dark', 'aorp_toggle_dark_callback' );
+add_action( 'wp_ajax_nopriv_aorp_toggle_dark', 'aorp_toggle_dark_callback' );

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -32,6 +32,13 @@
     margin-left: 5px;
 }
 
+.aorp-image-preview img {
+    max-width: 80px;
+    height: auto;
+    display: block;
+    margin-top: 5px;
+}
+
 @keyframes aorp-spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }

--- a/assets/js/admin/item-management.js
+++ b/assets/js/admin/item-management.js
@@ -1,5 +1,6 @@
 jQuery(function($){
     var ingOptions = $('.aorp-ing-select:first').html() || '';
+    bindImageUpload($('.aorp-add-form'));
     function showToast(text){
         var toast = $('<div class="aorp-toast" />').text(text);
         $('body').append(toast);
@@ -16,6 +17,7 @@ jQuery(function($){
                         $('#aorp-items-table tbody').append(resp.data.row);
                         form[0].reset();
                         form.find('.aorp-selected').empty();
+                        form.find('.aorp-image-preview').empty();
                     }else{
                         form.closest('tr').replaceWith(resp.data.row);
                         form.prev('tr').remove();
@@ -25,6 +27,20 @@ jQuery(function($){
             }else if(resp.data && resp.data.message){
                 alert(resp.data.message);
             }
+        });
+    }
+
+    function bindImageUpload(form){
+        form.find('.aorp-upload-image').off('click').on('click',function(e){
+            e.preventDefault();
+            var btn = $(this);
+            var frame = wp.media({title:'Bild auswählen',button:{text:'Auswählen'},multiple:false});
+            frame.on('select',function(){
+                var att = frame.state().get('selection').first().toJSON();
+                btn.siblings('.aorp-image-id').val(att.id);
+                btn.siblings('.aorp-image-preview').html('<img src="'+att.sizes.thumbnail.url+'" />');
+            });
+            frame.open();
         });
     }
 
@@ -79,12 +95,14 @@ jQuery(function($){
             '<p><select class="aorp-ing-select">'+ingOptions+'</select></p>'+
             '<div class="aorp-selected"></div>'+
             '<input type="hidden" name="item_ingredients" class="aorp-ing-text" value="'+(data.ingredients||'')+'" />'+
+            '<p><button class="button aorp-upload-image">Bild auswählen</button> <input type="hidden" name="item_image_id" class="aorp-image-id" value="'+(data.imageid||'')+'" /> <span class="aorp-image-preview">'+(data.imageurl?'<img src="'+data.imageurl+'" />':'')+'</span></p>'+
             '<button type="submit" class="button button-primary">Speichern</button> '+
             '<button class="button aorp-cancel">Abbrechen</button>'
         );
         cols.find('td').append(form);
         row.after(cols); row.hide();
         initIngredients(form);
+        bindImageUpload(form);
     });
 
     $(document).on('change','.aorp-ing-select',function(){

--- a/assets/js/frontend/script.js
+++ b/assets/js/frontend/script.js
@@ -43,7 +43,7 @@ jQuery(document).ready(function($){
             $('#aorp-toggle').html(aorp_ajax.icon_light);
             localStorage.setItem('aorp-dark-mode','off');
         }
-        $.post(aorp_ajax.url,{action:'aorp_toggle_dark'});
+        $.post(aorp_ajax.url,{action:'aorp_toggle_dark',mode:active?'on':'off'});
     }
 
     $('#aorp-toggle').on('click', function(){
@@ -57,8 +57,11 @@ jQuery(document).ready(function($){
     });
 
     var stored = localStorage.getItem('aorp-dark-mode');
+    var cookieMatch = document.cookie.match(/aorp_dark_mode=(on|off)/);
     if(stored){
         setDark(stored==='on');
+    }else if(cookieMatch){
+        setDark(cookieMatch[1]==='on');
     }else if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
         setDark(true);
     }

--- a/includes/ajax-handler.php
+++ b/includes/ajax-handler.php
@@ -72,9 +72,11 @@ class AORP_Ajax_Handler {
         $terms = get_the_terms( $id, 'aorp_menu_category' );
         $cat = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->name : '';
         $cat_id = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->term_id : 0;
+        $img_id = get_post_thumbnail_id( $id );
+        $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
         ob_start();
         ?>
-        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-price="<?php echo esc_attr( $price ); ?>" data-number="<?php echo esc_attr( $number ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>">
+        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-price="<?php echo esc_attr( $price ); ?>" data-number="<?php echo esc_attr( $number ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>" data-imageid="<?php echo esc_attr( $img_id ); ?>" data-imageurl="<?php echo esc_attr( $img_url ); ?>">
             <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $id ); ?>" /></td>
             <td><?php echo esc_html( $item->post_title ); ?></td>
             <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>
@@ -107,9 +109,11 @@ class AORP_Ajax_Handler {
         $terms = get_the_terms( $id, 'aorp_drink_category' );
         $cat = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->name : '';
         $cat_id = ( $terms && ! is_wp_error( $terms ) ) ? $terms[0]->term_id : 0;
+        $img_id = get_post_thumbnail_id( $id );
+        $img_url = $img_id ? wp_get_attachment_image_url( $img_id, 'thumbnail' ) : '';
         ob_start();
         ?>
-        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-sizes="<?php echo esc_attr( get_post_meta( $id, '_aorp_drink_sizes', true ) ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>">
+        <tr data-id="<?php echo esc_attr( $id ); ?>" data-title="<?php echo esc_attr( $item->post_title ); ?>" data-description="<?php echo esc_attr( $item->post_content ); ?>" data-sizes="<?php echo esc_attr( get_post_meta( $id, '_aorp_drink_sizes', true ) ); ?>" data-ingredients="<?php echo esc_attr( $ingredients ); ?>" data-category="<?php echo esc_attr( $cat_id ); ?>" data-imageid="<?php echo esc_attr( $img_id ); ?>" data-imageurl="<?php echo esc_attr( $img_url ); ?>">
             <td><input type="checkbox" name="item_ids[]" value="<?php echo esc_attr( $id ); ?>" /></td>
             <td><?php echo esc_html( $item->post_title ); ?></td>
             <td><?php echo esc_html( wp_trim_words( wp_strip_all_tags( $item->post_content ), 15 ) ); ?></td>

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -103,6 +103,9 @@ class AORP_Admin_Pages {
         echo '</select></p>';
         echo '<div class="aorp-selected"></div>';
         echo '<input type="hidden" name="item_ingredients" class="aorp-ing-text" />';
+        echo '<p><button class="button aorp-upload-image">' . __( 'Bild auswählen', 'aorp' ) . '</button> ';
+        echo '<input type="hidden" name="item_image_id" class="aorp-image-id" />';
+        echo '<span class="aorp-image-preview"></span></p>';
         echo '<p><button type="submit" class="button button-primary">Hinzufügen</button></p>';
         echo '</form>';
 

--- a/includes/class-aorp-settings.php
+++ b/includes/class-aorp-settings.php
@@ -17,7 +17,7 @@ class AORP_Settings {
      * Add settings page.
      */
     public function add_settings_page(): void {
-        add_submenu_page( 'aorp_manage', 'Einstellungen', 'Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'render_settings_page' ) );
+        add_submenu_page( 'aorp_manage', 'Karteninformationen/Einstellungen', 'Karteninformationen/Einstellungen', 'manage_options', 'aorp_settings', array( $this, 'render_settings_page' ) );
     }
 
     /**

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -47,7 +47,7 @@ class WPGMO_Template_Manager {
             $this->page_hook = add_menu_page( __('AIO-Grid-Vorlagen','aorp'), __('AIO-Grid-Vorlagen','aorp'), 'manage_network_options', 'wpgmo-templates', array( $this, 'render_page' ) );
             $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('AIO-Grid-Inhalte','aorp'), __('AIO-Grid-Inhalte','aorp'), 'manage_network_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
         } else {
-            $this->page_hook = add_menu_page( __('AIO-Grid-Vorlagen','aorp'), __('AIO-Grid-Vorlagen','aorp'), 'manage_options', 'wpgmo-templates', array( $this, 'render_page' ) );
+            $this->page_hook = add_submenu_page( 'aorp_manage', __('Grid-Vorlagen','aorp'), __('Grid-Vorlagen','aorp'), 'manage_options', 'wpgmo-templates', array( $this, 'render_page' ) );
             $this->overview_hook = add_submenu_page( 'wpgmo-templates', __('AIO-Grid-Inhalte','aorp'), __('AIO-Grid-Inhalte','aorp'), 'manage_options', 'wpgmo-overview', array( $this, 'render_overview_page' ) );
         }
     }


### PR DESCRIPTION
## Summary
- support image uploads for menu items
- include frontend dark mode toggle and persistence
- adjust admin menus to match requested structure
- allow grid templates submenu under main plugin menu
- minor styling for image preview

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/ajax-handler.php`
- `php -l includes/class-aorp-settings.php`
- `php -l includes/class-wpgmo-template-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68763692892c832998228baf715630b5