### PR TITLE
Fix PDF export and category sorting

### DIFF
--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -170,7 +170,14 @@ class AORP_Admin_Pages {
         }
 
         $items = get_posts( array( 'post_type' => $post_type, 'numberposts' => -1, 'orderby' => $orderby, 'order' => $order ) );
-        $cats  = get_terms( ( 'drinks' === $tab ) ? 'aorp_drink_category' : 'aorp_menu_category', array( 'hide_empty' => false ) );
+        $cats  = get_terms(
+            ( 'drinks' === $tab ) ? 'aorp_drink_category' : 'aorp_menu_category',
+            array(
+                'hide_empty' => false,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            )
+        );
         $ings  = get_posts( array( 'post_type' => 'aorp_ingredient', 'numberposts' => -1 ) );
 
         $nonce = wp_create_nonce( 'aorp_add_' . ( 'drinks' === $tab ? 'drink_item' : 'item' ) );
@@ -220,7 +227,14 @@ class AORP_Admin_Pages {
             wp_delete_term( intval( $_GET['delete_cat'] ), $taxonomy );
         }
 
-        $terms = get_terms( $taxonomy, array( 'hide_empty' => false ) );
+        $terms = get_terms(
+            $taxonomy,
+            array(
+                'hide_empty' => false,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            )
+        );
         echo '<form method="post">';
         wp_nonce_field( 'aorp_add_cat' );
         echo '<p><input type="text" name="new_cat" /> ';

--- a/includes/class-aorp-pdf-export.php
+++ b/includes/class-aorp-pdf-export.php
@@ -17,8 +17,25 @@ class AORP_PDF_Export {
      */
     public function export_pdf(): void {
         check_admin_referer( 'aorp_export_pdf' );
-        $foods  = get_posts( array( 'post_type' => 'aorp_menu_item', 'numberposts' => -1 ) );
-        $drinks = get_posts( array( 'post_type' => 'aorp_drink_item', 'numberposts' => -1 ) );
+        $foods  = get_posts(
+            array(
+                'post_type'   => 'aorp_menu_item',
+                'numberposts' => -1,
+                'meta_key'    => '_aorp_number',
+                'orderby'     => 'meta_value_num',
+                'order'       => 'ASC',
+                'post_status' => 'publish',
+            )
+        );
+        $drinks = get_posts(
+            array(
+                'post_type'   => 'aorp_drink_item',
+                'numberposts' => -1,
+                'orderby'     => 'title',
+                'order'       => 'ASC',
+                'post_status' => 'publish',
+            )
+        );
 
         $lines   = array();
         $lines[] = 'Speisekarte';

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -28,7 +28,14 @@ class AORP_Shortcodes {
             $columns_class = ' columns-' . $col;
         }
 
-        $categories = get_terms( 'aorp_menu_category', array( 'hide_empty' => false ) );
+        $categories = get_terms(
+            'aorp_menu_category',
+            array(
+                'hide_empty' => false,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            )
+        );
         if ( empty( $categories ) ) {
             $categories = array();
         }
@@ -83,7 +90,14 @@ class AORP_Shortcodes {
             $columns_class = ' columns-' . $col;
         }
 
-        $categories = get_terms( 'aorp_drink_category', array( 'hide_empty' => false ) );
+        $categories = get_terms(
+            'aorp_drink_category',
+            array(
+                'hide_empty' => false,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            )
+        );
         if ( empty( $categories ) ) {
             $categories = array();
         }


### PR DESCRIPTION
## Summary
- ensure PDF export includes menu items and sorts by item number
- sort menu and drink categories alphabetically in both admin and shortcode views

## Testing
- `php -l includes/class-aorp-pdf-export.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-aorp-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68764a59ab148329ab9ee1ae34f559aa