### PR TITLE
Restore map settings and template descriptions

### DIFF
--- a/assets/js/admin/wpgmo-grid-builder.js
+++ b/assets/js/admin/wpgmo-grid-builder.js
@@ -33,23 +33,24 @@ jQuery(function($){
 
     function renderList(){
         var addBtn = $('<button class="button button-primary"/>').text(WPGMO_GB.new).on('click',function(){
-            state = {slug:'',label:'',layout:[]};
+            state = {slug:'',label:'',desc:'',layout:[]};
             nextId = 1;
             editing = false;
             render();
         });
         container.append(addBtn);
-        var table = $('<table class="widefat striped"><thead><tr><th>Slug</th><th>'+WPGMO_GB.label+'</th><th>'+WPGMO_GB.actions+'</th></tr></thead><tbody></tbody></table>');
+        var table = $('<table class="widefat striped"><thead><tr><th>Slug</th><th>'+WPGMO_GB.label+'</th><th>'+WPGMO_GB.description+'</th><th>'+WPGMO_GB.actions+'</th></tr></thead><tbody></tbody></table>');
         $.each(templates,function(slug,tpl){
             var tr = $('<tr/>');
             var slugCell = $('<td/>').text(slug);
             if(slug === WPGMO_GB.default){ slugCell.append(' *'); }
             tr.append(slugCell);
             tr.append($('<td/>').text(tpl.label));
+            tr.append($('<td/>').text(tpl.desc || ''));
             var actions = $('<td/>');
             var editB = $('<button class="button"/>').text(WPGMO_GB.edit).on('click',function(){
                 if(isReadOnly(slug)) return;
-                state = {slug:slug,label:tpl.label,layout:tpl.layout||[]};
+                state = {slug:slug,label:tpl.label,desc:tpl.desc||'',layout:tpl.layout||[]};
                 nextId = getNextId(state.layout);
                 editing = true;
                 render();
@@ -75,6 +76,7 @@ jQuery(function($){
         var wrap = $('<div class="wpgmo-editor"/>');
         wrap.append('<p><label>'+WPGMO_GB.slug+'</label><br><input type="text" id="wpgmo-slug" '+(editing?'readonly':'')+' value="'+state.slug+'"></p>');
         wrap.append('<p><label>'+WPGMO_GB.label+'</label><br><input type="text" id="wpgmo-label" value="'+state.label+'"></p>');
+        wrap.append('<p><label>'+WPGMO_GB.description+'</label><br><textarea id="wpgmo-desc" rows="3">'+state.desc+'</textarea></p>');
         var layoutDiv = $('<div id="wpgmo-layout"/>');
         $.each(state.layout,function(i,row){
             var rdiv = $('<div class="wpgmo-row"/>');
@@ -128,9 +130,10 @@ jQuery(function($){
     function saveTemplate(){
         state.slug = $('#wpgmo-slug').val().trim();
         state.label = $('#wpgmo-label').val().trim();
-        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_save_template',nonce:WPGMO_GB.nonce,slug:state.slug,template:{label:state.label,layout:state.layout}},function(resp){
+        state.desc = $('#wpgmo-desc').val().trim();
+        $.post(WPGMO_GB.ajaxUrl,{action:'wpgmo_save_template',nonce:WPGMO_GB.nonce,slug:state.slug,template:{label:state.label,desc:state.desc,layout:state.layout}},function(resp){
             if(resp.success){
-                templates[state.slug] = {label:state.label,layout:state.layout};
+                templates[state.slug] = {label:state.label,desc:state.desc,layout:state.layout};
                 state = null;
                 render();
             }

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,10 @@ visible shortcodes are `[speisekarte]`, `[getraenkekarte]`,
 The number of columns displayed by the food and drink menus can be configured
 from the plugin settings page located under the "AIO-Restaurant" menu in the WordPress administration.
 
+Grid layouts used by the overlay shortcode can be managed from the
+"Einstellungen & Layouts" page. Each template has a label, optional description
+and flexible row/column layout.
+
 ## Translations and Samples
 
 Translations are managed with `languages/aorp.pot`. Example import files for CSV,

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -103,7 +103,6 @@ class AORP_Admin_Pages {
             remove_submenu_page( 'aio-restaurant', $slug );
         }
         remove_submenu_page( 'wpgmo-templates', 'wpgmo-overview' );
-        remove_menu_page( 'aio_leaflet_map' );
     }
 
     public function render_drink_page(): void {

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -83,6 +83,7 @@ class WPGMO_Template_Manager {
                 'slug'         => __( 'Slug', 'aorp' ),
                 'label'        => __( 'Bezeichnung', 'aorp' ),
                 'actions'      => __( 'Aktionen', 'aorp' ),
+                'description'  => __( 'Beschreibung', 'aorp' ),
                 'confirm'      => __( 'Vorlage löschen?', 'aorp' ),
                 'removeRow'    => __( 'Zeile entfernen', 'aorp' ),
                 'default'      => $default,
@@ -179,6 +180,7 @@ class WPGMO_Template_Manager {
     private function sanitize_template( $data ) {
         $out = array();
         $out['label']  = sanitize_text_field( $data['label'] );
+        $out['desc']   = isset( $data['desc'] ) ? sanitize_text_field( $data['desc'] ) : '';
         $out['layout'] = isset( $data['layout'] ) && is_array( $data['layout'] ) ? $data['layout'] : array();
         return $out;
     }


### PR DESCRIPTION
## Summary
- support editing grid template descriptions
- keep AIO-Karten menu so map settings are available again
- document grid layout management

## Testing
- `php -l includes/class-wpgmo-template-manager.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l all-in-one-restaurant-plugin.php`
- `node --check assets/js/admin/wpgmo-grid-builder.js`


------
https://chatgpt.com/codex/tasks/task_e_687d0c7913b08329a45a19a38c8b706a