### PR TITLE
Add Import/Export and Maps under AIO‑Restaurant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Dieses Plugin bietet eine moderne Verwaltung von Speise- und Getränkekarten fü
 - Einstellungsseite mit übersichtlichen Untertabs
 - CSV-Import sowie CSV- und PDF-Export
 - Darkmode Umschalter
+- Standortkarten über die Seite "AIO-Karten"
 
 ## Installation
 
 1. Plugin in den Ordner `wp-content/plugins` kopieren
 2. Im Backend aktivieren
 3. Die Administration erfolgt über den neuen Menüpunkt "AIO-Restaurant"
+4. Dort befinden sich auch Import/Export sowie die Seite "AIO-Karten"
 
 ## Shortcodes
 

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -82,6 +82,15 @@ class AORP_Admin_Pages {
             array( $this, 'render_settings_layouts_page' )
         );
 
+        add_submenu_page(
+            'aio-restaurant',
+            __( 'Import/Export', 'aorp' ),
+            __( 'Import/Export', 'aorp' ),
+            'manage_options',
+            'aio-import-export',
+            array( $this, 'render_import_export_page' )
+        );
+
         // Remove old duplicate or unused submenus from legacy versions
         $old = array(
             'aio-add-dish',
@@ -91,7 +100,6 @@ class AORP_Admin_Pages {
             'aio-grid-templates',
             'aio-overlay-builder',
             'aio-layout-preview',
-            'aio-import-export',
             'aio-pdf-export',
             'aio-rest-api',
             'aio-settings',

--- a/includes/maps.php
+++ b/includes/maps.php
@@ -17,7 +17,8 @@ class AIO_Leaflet_Map {
  * @return void
  */
     public function __construct() {
-        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+        // Register menu late so the parent from AORP_Admin_Pages exists.
+        add_action( 'admin_menu', array( $this, 'admin_menu' ), 60 );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
         add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_assets' ) );
         add_shortcode( 'aio_leaflet_map', array( $this, 'render_shortcode' ) );
@@ -52,7 +53,11 @@ class AIO_Leaflet_Map {
  * @return void
  */
     public function admin_enqueue_assets( $hook ) {
-        if ( 'toplevel_page_aio_leaflet_map' !== $hook ) {
+        $allowed = array(
+            'toplevel_page_aio_leaflet_map',
+            'aio-restaurant_page_aio_leaflet_map',
+        );
+        if ( ! in_array( $hook, $allowed, true ) ) {
             return;
         }
         $plugin_url = plugin_dir_url( __FILE__ );
@@ -69,7 +74,14 @@ class AIO_Leaflet_Map {
  * @return void
  */
     public function admin_menu() {
-        add_menu_page( 'AIO-Karten', 'AIO-Karten', 'manage_options', 'aio_leaflet_map', array( $this, 'settings_page' ), 'dashicons-location-alt' );
+        add_submenu_page(
+            'aio-restaurant',
+            'AIO-Karten',
+            'AIO-Karten',
+            'manage_options',
+            'aio_leaflet_map',
+            array( $this, 'settings_page' )
+        );
     }
 
 


### PR DESCRIPTION
## Summary
- move Leaflet map settings under the main plugin menu
- add Import/Export submenu
- document new menu locations

## Testing
- `php -l includes/maps.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l all-in-one-restaurant-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_687d0fe540c88329a33fcbfbf136a12b