### PR TITLE
Fix grid settings submenu missing

### DIFF
--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -105,12 +105,10 @@ class AORP_Admin_Pages {
             'aio-settings',
             'aio-darkmode',
             'aio-features',
-            'wpgmo-templates',
         );
         foreach ( $old as $slug ) {
             remove_submenu_page( 'aio-restaurant', $slug );
         }
-        remove_submenu_page( 'wpgmo-templates', 'wpgmo-overview' );
     }
 
     public function render_drink_page(): void {


### PR DESCRIPTION
## Summary
- stop removing `wpgmo-templates` submenu from AIO-Restaurant
- remove old call that hid the grid content page

## Testing
- `php -l includes/class-aorp-admin-pages.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687d11776f488329894b822080d5c4cc