### PR TITLE
Fix grid template menu location

### DIFF
--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -109,6 +109,9 @@ class AORP_Admin_Pages {
         foreach ( $old as $slug ) {
             remove_submenu_page( 'aio-restaurant', $slug );
         }
+        // Hide obsolete grid template menu entries
+        remove_submenu_page( 'aio-restaurant', 'wpgmo-templates' );
+        remove_submenu_page( 'wpgmo-templates', 'wpgmo-overview' );
     }
 
     public function render_drink_page(): void {


### PR DESCRIPTION
## Summary
- hide obsolete grid template submenu so clicking "Grid-Vorlagen" no longer leads to a missing page

## Testing
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-wpgmo-template-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_687d12ada1a88329aa71e4de8537764d