### PR TITLE
Restore grid template management

### DIFF
--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -109,9 +109,7 @@ class AORP_Admin_Pages {
         foreach ( $old as $slug ) {
             remove_submenu_page( 'aio-restaurant', $slug );
         }
-        // Hide obsolete grid template menu entries
-        remove_submenu_page( 'aio-restaurant', 'wpgmo-templates' );
-        remove_submenu_page( 'wpgmo-templates', 'wpgmo-overview' );
+        // Legacy grid template pages are now used again
     }
 
     public function render_drink_page(): void {

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -27,8 +27,9 @@ class WPGMO_Template_Manager {
  * @return void
  */
     private function __construct() {
-        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-        add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
+        // Run late so grid templates appear at the end of the submenu
+        add_action( 'admin_menu', array( $this, 'admin_menu' ), 60 );
+        add_action( 'network_admin_menu', array( $this, 'admin_menu' ), 60 );
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
         add_action( 'wp_ajax_wpgmo_save_template', array( $this, 'save_template' ) );
         add_action( 'wp_ajax_wpgmo_delete_template', array( $this, 'delete_template' ) );


### PR DESCRIPTION
## Summary
- show grid template pages again
- load template manager menu last so it appears at the bottom

## Testing
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-wpgmo-template-manager.php`

------
https://chatgpt.com/codex/tasks/task_e_687d141705948329aab6f919c5e4f76e