### PR TITLE
Add shortcode column to grid template list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Dieses Plugin bietet eine moderne Verwaltung von Speise- und Getränkekarten fü
 - CSV-Import sowie CSV- und PDF-Export
 - Darkmode Umschalter
 - Standortkarten über die Seite "AIO-Karten"
+- Grid-Vorlagen mit Shortcode-Ausgabe
 
 ## Installation
 
@@ -30,3 +31,8 @@ Die Anzahl der Spalten für Speise- und Getränkekarte lässt sich nun in den Pl
 ## Entwicklerhinweise
 
 Die Hauptfunktionen befinden sich im Verzeichnis `includes/`. Jede Komponente ist über Filter und Actions erweiterbar. Ein einfacher Autoloader lädt alle Klassen automatisch.
+
+## Changelog
+
+### 2.1.0
+* Grid-Vorlagen listen nun den zugehörigen Shortcode auf

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: All-In-One WordPress Restaurant Plugin
  * Description: Moderne Speisekartenverwaltung mit REST-API und Darkmode.
- * Version: 2.0
+ * Version: 2.1.0
  * Author: stb-srv
  * Text Domain: aorp
  */

--- a/assets/js/admin/wpgmo-grid-builder.js
+++ b/assets/js/admin/wpgmo-grid-builder.js
@@ -39,7 +39,7 @@ jQuery(function($){
             render();
         });
         container.append(addBtn);
-        var table = $('<table class="widefat striped"><thead><tr><th>Slug</th><th>'+WPGMO_GB.label+'</th><th>'+WPGMO_GB.description+'</th><th>'+WPGMO_GB.actions+'</th></tr></thead><tbody></tbody></table>');
+        var table = $('<table class="widefat striped"><thead><tr><th>Slug</th><th>'+WPGMO_GB.label+'</th><th>'+WPGMO_GB.description+'</th><th>'+WPGMO_GB.shortcode+'</th><th>'+WPGMO_GB.actions+'</th></tr></thead><tbody></tbody></table>');
         $.each(templates,function(slug,tpl){
             var tr = $('<tr/>');
             var slugCell = $('<td/>').text(slug);
@@ -47,6 +47,7 @@ jQuery(function($){
             tr.append(slugCell);
             tr.append($('<td/>').text(tpl.label));
             tr.append($('<td/>').text(tpl.desc || ''));
+            var scCell = $('<td/>').text('[wp_grid_menu_overlay id="'+slug+'"]');
             var actions = $('<td/>');
             var editB = $('<button class="button"/>').text(WPGMO_GB.edit).on('click',function(){
                 if(isReadOnly(slug)) return;
@@ -66,7 +67,7 @@ jQuery(function($){
                 delB.prop('disabled',true);
             }
             actions.append(editB).append(' ').append(dupB).append(' ').append(delB).append(' ').append(defB);
-            tr.append(actions);
+            tr.append(scCell).append(actions);
             table.find('tbody').append(tr);
         });
         container.append(table);

--- a/includes/class-wpgmo-template-manager.php
+++ b/includes/class-wpgmo-template-manager.php
@@ -85,6 +85,7 @@ class WPGMO_Template_Manager {
                 'label'        => __( 'Bezeichnung', 'aorp' ),
                 'actions'      => __( 'Aktionen', 'aorp' ),
                 'description'  => __( 'Beschreibung', 'aorp' ),
+                'shortcode'    => __( 'Shortcode', 'aorp' ),
                 'confirm'      => __( 'Vorlage löschen?', 'aorp' ),
                 'removeRow'    => __( 'Zeile entfernen', 'aorp' ),
                 'default'      => $default,


### PR DESCRIPTION
## Summary
- display shortcode for grid templates
- show the translation string in script localization
- document new shortcode info in README
- bump plugin version to 2.1.0

## Testing
- `php -l assets/js/admin/wpgmo-grid-builder.js`
- `php -l includes/class-wpgmo-template-manager.php`
- `php -l all-in-one-restaurant-plugin.php`
- `find . -name '*.php' -print | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_687d15f6c9e08329ab83423a69c719e6