### PR TITLE
Add frontend search toggle and admin tools

### DIFF
--- a/admin/import-export.php
+++ b/admin/import-export.php
@@ -1,0 +1,79 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function aio_import_export_menu_page() {
+    add_submenu_page(
+        'aio-restaurant',
+        __( 'Import/Export', 'aorp' ),
+        __( 'Import/Export', 'aorp' ),
+        'manage_options',
+        'aio-import-export-settings',
+        'aio_render_import_export_page'
+    );
+}
+add_action( 'admin_menu', 'aio_import_export_menu_page' );
+
+function aio_render_import_export_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Import/Export', 'aorp' ); ?></h1>
+        <h2><?php esc_html_e( 'Export', 'aorp' ); ?></h2>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'aio_export_settings' ); ?>
+            <input type="hidden" name="action" value="aio_export_settings" />
+            <?php submit_button( __( 'Einstellungen exportieren', 'aorp' ) ); ?>
+        </form>
+        <hr />
+        <h2><?php esc_html_e( 'Import', 'aorp' ); ?></h2>
+        <form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'aio_import_settings' ); ?>
+            <input type="hidden" name="action" value="aio_import_settings" />
+            <input type="file" name="aio_settings_file" accept=".json" required />
+            <?php submit_button( __( 'Einstellungen importieren', 'aorp' ) ); ?>
+        </form>
+    </div>
+    <?php
+}
+
+function aio_handle_export_settings() {
+    if ( ! current_user_can( 'manage_options' ) || ! check_admin_referer( 'aio_export_settings' ) ) {
+        wp_die( esc_html__( 'Nicht erlaubt', 'aorp' ) );
+    }
+
+    $data = array(
+        'aio_enable_search_filter' => get_option( 'aio_enable_search_filter' ),
+        'aorp_options'             => get_option( 'aorp_options' ),
+    );
+
+    $json = wp_json_encode( $data );
+    header( 'Content-Type: application/json' );
+    header( 'Content-Disposition: attachment; filename="aio-settings.json"' );
+    echo $json;
+    exit;
+}
+add_action( 'admin_post_aio_export_settings', 'aio_handle_export_settings' );
+
+function aio_handle_import_settings() {
+    if ( ! current_user_can( 'manage_options' ) || ! check_admin_referer( 'aio_import_settings' ) ) {
+        wp_die( esc_html__( 'Nicht erlaubt', 'aorp' ) );
+    }
+
+    if ( ! empty( $_FILES['aio_settings_file']['tmp_name'] ) ) {
+        $json = file_get_contents( $_FILES['aio_settings_file']['tmp_name'] );
+        $data = json_decode( $json, true );
+        if ( is_array( $data ) ) {
+            if ( isset( $data['aio_enable_search_filter'] ) ) {
+                update_option( 'aio_enable_search_filter', $data['aio_enable_search_filter'] );
+            }
+            if ( isset( $data['aorp_options'] ) ) {
+                update_option( 'aorp_options', $data['aorp_options'] );
+            }
+        }
+    }
+
+    wp_redirect( admin_url( 'admin.php?page=aio-import-export-settings&import=1' ) );
+    exit;
+}
+add_action( 'admin_post_aio_import_settings', 'aio_handle_import_settings' );

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function aio_register_general_settings() {
+    register_setting( 'aio_settings_group', 'aio_enable_search_filter' );
+}
+add_action( 'admin_init', 'aio_register_general_settings' );
+
+function aio_settings_menu_page() {
+    add_submenu_page(
+        'aio-restaurant',
+        __( 'Einstellungen', 'aorp' ),
+        __( 'Einstellungen', 'aorp' ),
+        'manage_options',
+        'aio-restaurant-settings',
+        'aio_render_settings_page'
+    );
+}
+add_action( 'admin_menu', 'aio_settings_menu_page' );
+
+function aio_render_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Plugin Einstellungen', 'aorp' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'aio_settings_group' );
+            ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row">
+                        <label for="aio_enable_search_filter"><?php esc_html_e( 'Such- & Filterfunktion im Frontend aktivieren', 'aorp' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="checkbox" id="aio_enable_search_filter" name="aio_enable_search_filter" value="1" <?php checked( get_option( 'aio_enable_search_filter' ), '1' ); ?> />
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/admin/shortcode-generator.php
+++ b/admin/shortcode-generator.php
@@ -1,0 +1,67 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function aio_shortcode_generator_menu_page() {
+    add_submenu_page(
+        'aio-restaurant',
+        __( 'Shortcode-Generator', 'aorp' ),
+        __( 'Shortcode-Generator', 'aorp' ),
+        'manage_options',
+        'aio-shortcode-generator',
+        'aio_render_shortcode_generator_page'
+    );
+}
+add_action( 'admin_menu', 'aio_shortcode_generator_menu_page' );
+
+function aio_render_shortcode_generator_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Shortcode-Generator', 'aorp' ); ?></h1>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><label for="aio_sc_type"><?php esc_html_e( 'Shortcode', 'aorp' ); ?></label></th>
+                <td>
+                    <select id="aio_sc_type">
+                        <option value="speisekarte">[speisekarte]</option>
+                        <option value="getraenkekarte">[getraenkekarte]</option>
+                        <option value="inhaltsstoffe">[inhaltsstoffe]</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="aio_sc_cols"><?php esc_html_e( 'Spalten', 'aorp' ); ?></label></th>
+                <td><input type="text" id="aio_sc_cols" placeholder="2" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="aio_sc_cats"><?php esc_html_e( 'Kategorien', 'aorp' ); ?></label></th>
+                <td><input type="text" id="aio_sc_cats" placeholder="1,2" /></td>
+            </tr>
+        </table>
+        <p><input type="text" id="aio_generated_sc" readonly style="width:100%" /></p>
+        <p><button class="button" id="aio_copy_sc"><?php esc_html_e( 'Copy to Clipboard', 'aorp' ); ?></button></p>
+    </div>
+    <script>
+    jQuery(function($){
+        function build(){
+            var type = $('#aio_sc_type').val();
+            var shortcode = '['+type;
+            var cols = $('#aio_sc_cols').val();
+            var cats = $('#aio_sc_cats').val();
+            if(cols){ shortcode += ' columns="'+cols+'"'; }
+            if(cats){ shortcode += ' categories="'+cats+'"'; }
+            shortcode += ']';
+            $('#aio_generated_sc').val(shortcode);
+        }
+        $('#aio_sc_type, #aio_sc_cols, #aio_sc_cats').on('input change', build);
+        $('#aio_copy_sc').on('click', function(e){
+            e.preventDefault();
+            $('#aio_generated_sc').select();
+            document.execCommand('copy');
+        });
+        build();
+    });
+    </script>
+    <?php
+}

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -21,6 +21,10 @@ require_once __DIR__ . '/includes/class-wp-grid-menu-overlay.php';
 require_once __DIR__ . '/includes/class-wpgmo-meta-box.php';
 require_once __DIR__ . '/includes/class-wpgmo-template-manager.php';
 require_once __DIR__ . '/includes/maps.php';
+require_once plugin_dir_path( __FILE__ ) . 'admin/settings.php';
+require_once plugin_dir_path( __FILE__ ) . 'admin/import-export.php';
+require_once plugin_dir_path( __FILE__ ) . 'admin/shortcode-generator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/frontend-search.php';
 
 if ( ! function_exists( 'aorp_wp_kses_post_iframe' ) ) {
     /**

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -40,11 +40,9 @@ class AORP_Shortcodes {
             $categories = array();
         }
         ob_start();
-        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="Suche..." /><button id="aorp-close-cats" class="aorp-close-cats">Kategorien schließen</button><div id="aorp-search-results"></div></div>';
-        echo '<p class="aorp-note">Bitte klicken Sie auf die Kategorien, um die Speisen zu sehen.</p>';
         echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
-            echo '<div class="aorp-category">' . esc_html( $cat->name ) . '</div>';
+            echo '<div class="aorp-category" data-cat="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</div>';
             echo '<div class="aorp-items">';
             $items = get_posts( array( 'post_type' => 'aorp_menu_item', 'numberposts' => -1, 'tax_query' => array( array( 'taxonomy' => 'aorp_menu_category', 'terms' => $cat->term_id ) ) ) );
             foreach ( $items as $food ) {
@@ -102,11 +100,9 @@ class AORP_Shortcodes {
             $categories = array();
         }
         ob_start();
-        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="Suche..." /><button id="aorp-close-cats" class="aorp-close-cats">Kategorien schließen</button><div id="aorp-search-results"></div></div>';
-        echo '<p class="aorp-note">Bitte klicken Sie auf die Kategorien, um die Speisen zu sehen.</p>';
         echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
-            echo '<div class="aorp-category">' . esc_html( $cat->name ) . '</div>';
+            echo '<div class="aorp-category" data-cat="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</div>';
             echo '<div class="aorp-items">';
             $items = get_posts( array( 'post_type' => 'aorp_drink_item', 'numberposts' => -1, 'tax_query' => array( array( 'taxonomy' => 'aorp_drink_category', 'terms' => $cat->term_id ) ) ) );
             foreach ( $items as $drink ) {

--- a/includes/frontend-search.php
+++ b/includes/frontend-search.php
@@ -1,0 +1,64 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function aio_frontend_search_filter( $output, $tag, $attr ) {
+    if ( get_option( 'aio_enable_search_filter' ) !== '1' ) {
+        return $output;
+    }
+
+    if ( 'speisekarte' === $tag ) {
+        $taxonomy = 'aorp_menu_category';
+    } elseif ( 'getraenkekarte' === $tag ) {
+        $taxonomy = 'aorp_drink_category';
+    } else {
+        return $output;
+    }
+
+    $terms = get_terms( $taxonomy, array( 'hide_empty' => false, 'orderby' => 'name', 'order' => 'ASC' ) );
+    $dropdown = '<select class="aio-category-filter"><option value="">' . esc_html__( 'Alle Kategorien', 'aorp' ) . '</option>';
+    foreach ( $terms as $term ) {
+        $dropdown .= '<option value="' . esc_attr( $term->term_id ) . '">' . esc_html( $term->name ) . '</option>';
+    }
+    $dropdown .= '</select>';
+    $search = '<input type="text" class="aio-search-field" placeholder="' . esc_attr__( 'Suche', 'aorp' ) . '" />';
+    $ui = '<div class="aio-search-filter-container">' . $search . ' ' . $dropdown . '</div>';
+
+    return $ui . $output;
+}
+add_filter( 'do_shortcode_tag', 'aio_frontend_search_filter', 10, 3 );
+
+function aio_frontend_search_filter_script() {
+    if ( ! get_option( 'aio_enable_search_filter' ) ) {
+        return;
+    }
+    ?>
+    <script>
+    jQuery(function($){
+        function filterList(container){
+            var search = container.find('.aio-search-field').val().toLowerCase();
+            var cat = container.find('.aio-category-filter').val();
+            var list = container.next('.aorp-menu');
+            list.find('.aorp-category').each(function(){
+                var cid = $(this).data('cat');
+                var showCat = !cat || cat==cid;
+                var items = $(this).next('.aorp-items').find('.aorp-item');
+                items.each(function(){
+                    var text = $(this).text().toLowerCase();
+                    var match = text.indexOf(search) !== -1;
+                    $(this).toggle(match && showCat);
+                });
+                var anyVisible = items.filter(':visible').length>0;
+                $(this).toggle(anyVisible);
+                $(this).next('.aorp-items').toggle(anyVisible);
+            });
+        }
+        $(document).on('input change', '.aio-search-field, .aio-category-filter', function(){
+            filterList($(this).closest('.aio-search-filter-container'));
+        });
+    });
+    </script>
+    <?php
+}
+add_action( 'wp_footer', 'aio_frontend_search_filter_script' );


### PR DESCRIPTION
## Summary
- add a settings page with search & filter toggle
- add import/export page for plugin settings
- add shortcode generator page
- inject optional search/filter UI for shortcodes
- include new modules from main plugin file

## Testing
- `php -l admin/settings.php`
- `php -l admin/import-export.php`
- `php -l admin/shortcode-generator.php`
- `php -l includes/frontend-search.php`
- `php -l includes/class-aorp-shortcodes.php`

------
https://chatgpt.com/codex/tasks/task_e_687d1fc2b54c8329820e75e35f2d526d