### PR TITLE
Add contact message management tab

### DIFF
--- a/admin/contact-messages.php
+++ b/admin/contact-messages.php
@@ -1,0 +1,46 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( isset( $_GET['delete_msg'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'aorp_delete_msg_' . intval( $_GET['delete_msg'] ) ) ) {
+    wp_delete_post( intval( $_GET['delete_msg'] ), true );
+    echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Nachricht gelöscht.', 'aorp' ) . '</p></div>';
+}
+
+$messages = get_posts( array(
+    'post_type'   => 'aorp_contact_message',
+    'numberposts' => -1,
+    'orderby'     => 'date',
+    'order'       => 'DESC',
+) );
+
+echo '<div class="wrap"><h1>' . esc_html__( 'Kontaktnachrichten', 'aorp' ) . '</h1>';
+if ( $messages ) {
+    echo '<table class="widefat"><thead><tr>';
+    echo '<th>' . esc_html__( 'Datum', 'aorp' ) . '</th>';
+    echo '<th>' . esc_html__( 'Name', 'aorp' ) . '</th>';
+    echo '<th>' . esc_html__( 'E-Mail', 'aorp' ) . '</th>';
+    echo '<th>' . esc_html__( 'Betreff', 'aorp' ) . '</th>';
+    echo '<th>' . esc_html__( 'Nachricht', 'aorp' ) . '</th>';
+    echo '<th>' . esc_html__( 'Aktionen', 'aorp' ) . '</th>';
+    echo '</tr></thead><tbody>';
+    foreach ( $messages as $msg ) {
+        $name  = get_post_meta( $msg->ID, '_aorp_contact_name', true );
+        $email = get_post_meta( $msg->ID, '_aorp_contact_email', true );
+        $del_link = wp_nonce_url( add_query_arg( array( 'delete_msg' => $msg->ID ) ), 'aorp_delete_msg_' . $msg->ID );
+        echo '<tr>';
+        echo '<td>' . esc_html( get_date_from_gmt( $msg->post_date_gmt, 'd.m.Y H:i' ) ) . '</td>';
+        echo '<td>' . esc_html( $name ) . '</td>';
+        echo '<td><a href="mailto:' . esc_attr( $email ) . '">' . esc_html( $email ) . '</a></td>';
+        echo '<td>' . esc_html( $msg->post_title ) . '</td>';
+        echo '<td>' . esc_html( $msg->post_content ) . '</td>';
+        echo '<td><a href="' . esc_url( $del_link ) . '">x</a></td>';
+        echo '</tr>';
+    }
+    echo '</tbody></table>';
+} else {
+    echo '<p>' . esc_html__( 'Keine Nachrichten vorhanden.', 'aorp' ) . '</p>';
+}
+echo '</div>';
+

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -51,6 +51,7 @@ use AIO_Restaurant_Plugin\AORP_CSV_Handler;
 use AIO_Restaurant_Plugin\AORP_PDF_Export;
 use AIO_Restaurant_Plugin\AORP_Settings;
 use AIO_Restaurant_Plugin\AORP_REST_API;
+use AIO_Restaurant_Plugin\AORP_Contact_Messages;
 
 /**
  * Initialize plugin components.
@@ -76,6 +77,9 @@ function aorp_init_plugin(): void {
 
     $rest = new AORP_REST_API();
     $rest->register();
+
+    $contact = new AORP_Contact_Messages();
+    $contact->register();
 
     if ( class_exists( 'WP_Grid_Menu_Overlay' ) ) {
         WP_Grid_Menu_Overlay::instance();

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -91,6 +91,15 @@ class AORP_Admin_Pages {
             array( $this, 'render_import_export_page' )
         );
 
+        add_submenu_page(
+            'aio-restaurant',
+            __( 'Kontaktnachrichten', 'aorp' ),
+            __( 'Kontaktnachrichten', 'aorp' ),
+            'manage_options',
+            'aio-contact-messages',
+            array( $this, 'render_contact_messages_page' )
+        );
+
         // Remove old duplicate or unused submenus from legacy versions
         $old = array(
             'aio-add-dish',
@@ -218,6 +227,10 @@ class AORP_Admin_Pages {
             </form>
             <p><button class="button button-primary" disabled>YAML Export</button> <button class="button button-primary" disabled>JSON Export</button></p>
         <?php
+    }
+
+    public function render_contact_messages_page(): void {
+        include dirname( __DIR__ ) . '/admin/contact-messages.php';
     }
 
     public function render_grid_templates_page(): void {

--- a/includes/class-aorp-contact-messages.php
+++ b/includes/class-aorp-contact-messages.php
@@ -1,0 +1,46 @@
+<?php
+namespace AIO_Restaurant_Plugin;
+
+use function add_action;
+use function admin_url;
+use function delete_transient;
+use function esc_url;
+use function get_transient;
+use function set_transient;
+use function __;
+
+/**
+ * Handles contact message notifications.
+ */
+class AORP_Contact_Messages {
+    /**
+     * Register hooks.
+     */
+    public function register(): void {
+        add_action( 'save_post_aorp_contact_message', array( $this, 'flag_new_message' ), 10, 3 );
+        add_action( 'admin_notices', array( $this, 'admin_notice' ) );
+    }
+
+    /**
+     * Flag a new message via transient.
+     */
+    public function flag_new_message( int $post_id, $post, bool $update ): void {
+        if ( $update ) {
+            return;
+        }
+        set_transient( 'aorp_new_contact_message', 1 );
+    }
+
+    /**
+     * Display admin notice with link to messages page.
+     */
+    public function admin_notice(): void {
+        if ( ! get_transient( 'aorp_new_contact_message' ) ) {
+            return;
+        }
+        delete_transient( 'aorp_new_contact_message' );
+        $url = admin_url( 'admin.php?page=aio-contact-messages' );
+        echo '<div class="notice notice-info is-dismissible"><p>' . sprintf( __( 'Neue Kontaktnachricht erhalten. <a href="%s">Zur Nachrichtenseite</a>', 'aorp' ), esc_url( $url ) ) . '</p></div>';
+    }
+}
+

--- a/includes/class-aorp-post-types.php
+++ b/includes/class-aorp-post-types.php
@@ -25,6 +25,7 @@ class AORP_Post_Types {
         add_action( 'init', array( $this, 'register_food_post_type' ) );
         add_action( 'init', array( $this, 'register_drink_post_type' ) );
         add_action( 'init', array( $this, 'register_ingredient_post_type' ) );
+        add_action( 'init', array( $this, 'register_contact_post_type' ) );
         add_action( 'init', array( $this, 'register_taxonomies' ) );
     }
 
@@ -81,6 +82,24 @@ class AORP_Post_Types {
                 'public'   => false,
                 'show_ui'  => false,
                 'supports' => array( 'title' ),
+            )
+        );
+    }
+
+    /**
+     * Contact message post type.
+     */
+    public function register_contact_post_type(): void {
+        register_post_type(
+            'aorp_contact_message',
+            array(
+                'labels'   => array(
+                    'name'          => __( 'Kontaktnachrichten', 'aorp' ),
+                    'singular_name' => __( 'Kontaktnachricht', 'aorp' ),
+                ),
+                'public'   => false,
+                'show_ui'  => false,
+                'supports' => array( 'title', 'editor' ),
             )
         );
     }


### PR DESCRIPTION
## Summary
- add new `Kontaktnachrichten` admin tab to view and remove stored messages
- introduce `aorp_contact_message` post type and notification handler linking to the messages page
- display contact messages in a table with delete links

## Testing
- `php -l includes/class-aorp-post-types.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-aorp-contact-messages.php`
- `php -l admin/contact-messages.php`
- `php -l all-in-one-restaurant-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_688fa2cc5b948329bec76b7228135577