### PR TITLE
Fix contact message deletion and bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ Die Hauptfunktionen befinden sich im Verzeichnis `includes/`. Jede Komponente is
 
 ### 2.2.0
 * Grid-Inhalte lassen sich nun über einen Tab der Vorlagen-Seite bearbeiten
+
+### 2.3.0
+* Verwaltung von Kontaktnachrichten mit Löschfunktion

--- a/admin/contact-messages.php
+++ b/admin/contact-messages.php
@@ -3,8 +3,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( isset( $_GET['delete_msg'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'aorp_delete_msg_' . intval( $_GET['delete_msg'] ) ) ) {
-    wp_delete_post( intval( $_GET['delete_msg'] ), true );
+if (
+    isset( $_GET['delete_msg'], $_GET['_wpnonce'] ) &&
+    wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'aorp_delete_msg_' . absint( $_GET['delete_msg'] ) )
+) {
+    wp_delete_post( absint( $_GET['delete_msg'] ), true );
     echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Nachricht gelöscht.', 'aorp' ) . '</p></div>';
 }
 

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: All-In-One WordPress Restaurant Plugin
  * Description: Moderne Speisekartenverwaltung mit REST-API und Darkmode.
- * Version: 2.1.0
+ * Version: 2.3.0
  * Author: stb-srv
  * Text Domain: aorp
  */


### PR DESCRIPTION
## Summary
- guard contact message deletion with nonce presence and sanitized input
- bump plugin version to 2.3.0 and document new contact message management feature

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l admin/contact-messages.php`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688fa4db6dcc8329b87562f6053df7f7