### PR TITLE
Fix admin settings tab links

### DIFF
--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -148,7 +148,13 @@ class AORP_Admin_Pages {
             'grid-contents' => __( 'AIO-Grid Inhalte', 'aorp' ),
         );
         foreach ( $tabs as $key => $label ) {
-            $url = add_query_arg( array( 'page' => 'aio-settings-layouts', 'tab' => $key ) );
+            $url    = add_query_arg(
+                array(
+                    'page' => 'aio-settings-layouts',
+                    'tab'  => $key,
+                ),
+                admin_url( 'admin.php' )
+            );
             $active = ( $tab === $key ) ? ' nav-tab-active' : '';
             echo '<a href="' . esc_url( $url ) . '" class="nav-tab' . $active . '">' . esc_html( $label ) . '</a>';
         }


### PR DESCRIPTION
## Summary
- ensure settings/layout tabs use absolute admin URLs so navigation no longer redirects back to contact messages

## Testing
- `npm test` *(fails: package.json missing)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa7a124188329a5dede24cc6c9bfc