### PR TITLE
Fix legacy admin slug for AIO-Restaurant

### DIFF
--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -126,3 +126,14 @@ function aorp_toggle_dark_callback() {
 }
 add_action( 'wp_ajax_aorp_toggle_dark', 'aorp_toggle_dark_callback' );
 add_action( 'wp_ajax_nopriv_aorp_toggle_dark', 'aorp_toggle_dark_callback' );
+
+/**
+ * Redirect legacy admin slug with a typo to the correct dashboard.
+ */
+function aorp_fix_legacy_menu_slug(): void {
+    if ( isset( $_GET['page'] ) && 'aio-resturant' === $_GET['page'] ) {
+        wp_safe_redirect( admin_url( 'admin.php?page=aio-restaurant' ) );
+        exit;
+    }
+}
+add_action( 'admin_init', 'aorp_fix_legacy_menu_slug' );


### PR DESCRIPTION
## Summary
- redirect outdated `aio-resturant` admin URL to current dashboard

## Testing
- `php -v` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890675fe0148329aeccae9a151f8077