### PR TITLE
Fix admin menu navigation

### DIFF
--- a/admin/shortcode-generator.php
+++ b/admin/shortcode-generator.php
@@ -3,18 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-function aio_shortcode_generator_menu_page() {
-    add_submenu_page(
-        'aio-restaurant',
-        __( 'Shortcode-Generator', 'aorp' ),
-        __( 'Shortcode-Generator', 'aorp' ),
-        'manage_options',
-        'aio-shortcode-generator',
-        'aio_render_shortcode_generator_page'
-    );
-}
-add_action( 'admin_menu', 'aio_shortcode_generator_menu_page' );
-
 function aio_render_shortcode_generator_page() {
     ?>
     <div class="wrap">

--- a/all-in-one-restaurant-plugin.php
+++ b/all-in-one-restaurant-plugin.php
@@ -21,8 +21,6 @@ require_once __DIR__ . '/includes/class-wp-grid-menu-overlay.php';
 require_once __DIR__ . '/includes/class-wpgmo-meta-box.php';
 require_once __DIR__ . '/includes/class-wpgmo-template-manager.php';
 require_once __DIR__ . '/includes/maps.php';
-require_once plugin_dir_path( __FILE__ ) . 'admin/settings.php';
-require_once plugin_dir_path( __FILE__ ) . 'admin/import-export.php';
 require_once plugin_dir_path( __FILE__ ) . 'admin/shortcode-generator.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/frontend-search.php';
 

--- a/includes/class-aorp-admin-pages.php
+++ b/includes/class-aorp-admin-pages.php
@@ -35,8 +35,6 @@ class AORP_Admin_Pages {
             26
         );
 
-        // Replace automatic submenu with a dedicated Dashboard entry
-        remove_submenu_page( 'aio-restaurant', 'aio-restaurant' );
         add_submenu_page(
             'aio-restaurant',
             __( 'Dashboard', 'aorp' ),
@@ -100,6 +98,17 @@ class AORP_Admin_Pages {
             array( $this, 'render_contact_messages_page' )
         );
 
+        add_submenu_page(
+            'aio-restaurant',
+            __( 'Shortcode-Generator', 'aorp' ),
+            __( 'Shortcode-Generator', 'aorp' ),
+            'manage_options',
+            'aio-shortcode-generator',
+            'aio_render_shortcode_generator_page'
+        );
+
+        remove_submenu_page( 'aio-restaurant', 'aio-restaurant' );
+
         // Remove old duplicate or unused submenus from legacy versions
         $old = array(
             'aio-add-dish',
@@ -112,6 +121,8 @@ class AORP_Admin_Pages {
             'aio-pdf-export',
             'aio-rest-api',
             'aio-settings',
+            'aio-restaurant-settings',
+            'aio-import-export-settings',
             'aio-darkmode',
             'aio-features',
         );

--- a/includes/class-aorp-settings.php
+++ b/includes/class-aorp-settings.php
@@ -25,11 +25,13 @@ class AORP_Settings {
      */
     public function settings_init(): void {
         register_setting( 'aorp_settings_general', 'aorp_options' );
+        register_setting( 'aorp_settings_general', 'aio_enable_search_filter' );
         /* Design and license settings removed */
 
         add_settings_section( 'aorp_general', __( 'Allgemein', 'aorp' ), '__return_false', 'aorp_settings_general' );
         add_settings_field( 'food_columns', __( 'Spalten Speisekarte', 'aorp' ), array( $this, 'field_food_columns' ), 'aorp_settings_general', 'aorp_general' );
         add_settings_field( 'drink_columns', __( 'Spalten Getränkekarte', 'aorp' ), array( $this, 'field_drink_columns' ), 'aorp_settings_general', 'aorp_general' );
+        add_settings_field( 'enable_search_filter', __( 'Such- & Filterfunktion im Frontend aktivieren', 'aorp' ), array( $this, 'field_enable_search_filter' ), 'aorp_settings_general', 'aorp_general' );
 
         /* Design and license sections removed */
     }
@@ -58,6 +60,14 @@ class AORP_Settings {
             printf( '<option value="%1$d" %2$s>%1$d</option>', $col, selected( $value, $col, false ) );
         }
         echo '</select>';
+    }
+
+    /**
+     * Render search filter checkbox.
+     */
+    public function field_enable_search_filter(): void {
+        $value = get_option( 'aio_enable_search_filter' );
+        echo '<input type="checkbox" name="aio_enable_search_filter" value="1" ' . checked( $value, '1', false ) . ' />';
     }
 
     /* Design and license field renderers removed */


### PR DESCRIPTION
## Summary
- Remove outdated admin settings and import/export menu registrations
- Ensure AIO-Restaurant main tab opens dashboard without extra submenu
- Register Shortcode Generator and search-filter setting within unified admin pages

## Testing
- `php -l all-in-one-restaurant-plugin.php`
- `php -l admin/shortcode-generator.php`
- `php -l includes/class-aorp-admin-pages.php`
- `php -l includes/class-aorp-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_689069d4d4b88329b9435b8ca8144d2c