### PR TITLE
Enable frontend search filter by default

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 function aio_register_general_settings() {
-    register_setting( 'aio_settings_group', 'aio_enable_search_filter' );
+    register_setting( 'aio_settings_group', 'aio_enable_search_filter', array( 'default' => '1' ) );
 }
 add_action( 'admin_init', 'aio_register_general_settings' );
 
@@ -34,7 +34,7 @@ function aio_render_settings_page() {
                         <label for="aio_enable_search_filter"><?php esc_html_e( 'Such- & Filterfunktion im Frontend aktivieren', 'aorp' ); ?></label>
                     </th>
                     <td>
-                        <input type="checkbox" id="aio_enable_search_filter" name="aio_enable_search_filter" value="1" <?php checked( get_option( 'aio_enable_search_filter' ), '1' ); ?> />
+                        <input type="checkbox" id="aio_enable_search_filter" name="aio_enable_search_filter" value="1" <?php checked( get_option( 'aio_enable_search_filter', '1' ), '1' ); ?> />
                     </td>
                 </tr>
             </table>

--- a/includes/class-aorp-settings.php
+++ b/includes/class-aorp-settings.php
@@ -25,7 +25,7 @@ class AORP_Settings {
      */
     public function settings_init(): void {
         register_setting( 'aorp_settings_general', 'aorp_options' );
-        register_setting( 'aorp_settings_general', 'aio_enable_search_filter' );
+        register_setting( 'aorp_settings_general', 'aio_enable_search_filter', array( 'default' => '1' ) );
         /* Design and license settings removed */
 
         add_settings_section( 'aorp_general', __( 'Allgemein', 'aorp' ), '__return_false', 'aorp_settings_general' );
@@ -66,7 +66,7 @@ class AORP_Settings {
      * Render search filter checkbox.
      */
     public function field_enable_search_filter(): void {
-        $value = get_option( 'aio_enable_search_filter' );
+        $value = get_option( 'aio_enable_search_filter', '1' );
         echo '<input type="checkbox" name="aio_enable_search_filter" value="1" ' . checked( $value, '1', false ) . ' />';
     }
 

--- a/includes/frontend-search.php
+++ b/includes/frontend-search.php
@@ -4,7 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 function aio_frontend_search_filter( $output, $tag, $attr ) {
-    if ( get_option( 'aio_enable_search_filter' ) !== '1' ) {
+    // Enable search filter by default; option allows opt-out.
+    if ( '1' !== get_option( 'aio_enable_search_filter', '1' ) ) {
         return $output;
     }
 
@@ -30,7 +31,8 @@ function aio_frontend_search_filter( $output, $tag, $attr ) {
 add_filter( 'do_shortcode_tag', 'aio_frontend_search_filter', 10, 3 );
 
 function aio_frontend_search_filter_script() {
-    if ( ! get_option( 'aio_enable_search_filter' ) ) {
+    // Skip script if feature explicitly disabled.
+    if ( '1' !== get_option( 'aio_enable_search_filter', '1' ) ) {
         return;
     }
     ?>


### PR DESCRIPTION
## Summary
- Show the search and category filter above menu shortcodes automatically
- Register search filter setting with a default of enabled and ensure admin UI reflects it

## Testing
- `php -l includes/frontend-search.php`
- `php -l includes/class-aorp-settings.php`
- `php -l admin/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a06dbabf508329b2f358f268570299