### PR TITLE
feat: overlay search results

### DIFF
--- a/assets/js/frontend/script.js
+++ b/assets/js/frontend/script.js
@@ -8,8 +8,10 @@ jQuery(document).ready(function($){
     function performSearch(val){
         val = val.toLowerCase();
         var list = $('#aorp-search-results');
+        var overlay = $('#aorp-search-overlay');
         list.empty();
         if(val === ''){
+            overlay.hide();
             return;
         }
         $('.aorp-item').each(function(){
@@ -17,10 +19,25 @@ jQuery(document).ready(function($){
                 list.append($(this).clone());
             }
         });
+        overlay.show();
     }
 
     $('#aorp-search-input').on('input', function(){
         performSearch($(this).val());
+    });
+
+    $('#aorp-search-overlay').on('click', function(e){
+        if(e.target.id==='aorp-search-overlay'){
+            $(this).hide();
+            $('#aorp-search-input').val('');
+        }
+    });
+
+    $(document).on('keydown', function(e){
+        if(e.key==='Escape'){
+            $('#aorp-search-overlay').hide();
+            $('#aorp-search-input').val('');
+        }
     });
 
     $('#aorp-close-cats').on('click', function(){

--- a/assets/style.css
+++ b/assets/style.css
@@ -2,7 +2,7 @@
 .aorp-menu{margin:1em 0}
 .aorp-note{margin-bottom:0.5em;font-weight:bold}
 #aorp-search-input{width:50%;max-width:400px;padding:0.5em 1em;border-radius:4px;border:1px solid #ccc;font-size:1rem;margin:0 auto;display:block;background:#fff;color:#000}
-.aorp-search-wrapper{text-align:center;position:relative;margin:2rem 0}
+.aorp-search-wrapper{text-align:center;position:relative;margin:2rem 0;z-index:10000}
 .aorp-close-cats{padding:0.5em 1em;background:#eee;color:#000;border:1px solid #ccc;border-radius:6px;cursor:pointer}
 body.aorp-dark .aorp-close-cats{background:#444;color:#fff;border-color:#666}
 .aorp-category{cursor:pointer;background:#eee;padding:0.5em;margin-bottom:0.5em;display:flex;align-items:center;min-height:40px;height:60px;line-height:1.2;box-sizing:border-box;border-radius:6px;box-shadow:0 1px 2px rgba(0,0,0,0.1)}
@@ -58,7 +58,7 @@ body.aorp-dark .aorp-ingredients-legend{background:#555;color:#fff;border-color:
 }
 
 /* Overlay search */
-#aorp-search-overlay{position:relative;text-align:center;margin:2rem auto}
+#aorp-search-overlay{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);overflow:auto;z-index:9999;padding:2rem;text-align:center}
 #aorp-search-results .aorp-item{background:#f9f9f9;margin:0.5rem 0;padding:0.75rem 1rem;border-radius:4px;color:#000}
 #aorp-search-results .aorp-item-title{margin:0;font-size:1.1rem}
 #aorp-search-results .aorp-item-price{float:right;font-size:0.95rem;opacity:0.8}

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -9,6 +9,24 @@ use function AIO_Restaurant_Plugin\ingredient_labels;
 
 class AORP_Shortcodes {
     /**
+     * Track if the search UI has been printed.
+     *
+     * @var bool
+     */
+    private static $search_rendered = false;
+
+    /**
+     * Render search input and overlay once.
+     */
+    private function render_search_ui(): void {
+        if ( self::$search_rendered ) {
+            return;
+        }
+        self::$search_rendered = true;
+        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="' . esc_attr__( 'Suche...', 'aorp' ) . '" /></div>';
+        echo '<div id="aorp-search-overlay"><div id="aorp-search-results"></div></div>';
+    }
+    /**
      * Register shortcodes.
      */
     public function register(): void {
@@ -40,6 +58,7 @@ class AORP_Shortcodes {
             $categories = array();
         }
         ob_start();
+        $this->render_search_ui();
         echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
             echo '<div class="aorp-category" data-cat="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</div>';
@@ -100,6 +119,7 @@ class AORP_Shortcodes {
             $categories = array();
         }
         ob_start();
+        $this->render_search_ui();
         echo '<div class="aorp-menu' . esc_attr( $columns_class ) . '">';
         foreach ( $categories as $cat ) {
             echo '<div class="aorp-category" data-cat="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</div>';


### PR DESCRIPTION
## Summary
- render search UI with dark overlay on food and drink menus
- show matching items in overlay and allow closing via click or Esc

## Testing
- `php -l includes/class-aorp-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a06f03e4c883299d19bf6dbe79d1a6