### PR TITLE
feat: enhance search UI with overlay

### DIFF
--- a/assets/js/frontend/script.js
+++ b/assets/js/frontend/script.js
@@ -3,43 +3,6 @@ jQuery(document).ready(function($){
         $(this).next('.aorp-items').slideToggle();
     });
 
-
-
-    function performSearch(val){
-        val = val.toLowerCase();
-        var list = $('#aorp-search-results');
-        var overlay = $('#aorp-search-overlay');
-        list.empty();
-        if(val === ''){
-            overlay.hide();
-            return;
-        }
-        $('.aorp-item').each(function(){
-            if($(this).text().toLowerCase().indexOf(val) !== -1){
-                list.append($(this).clone());
-            }
-        });
-        overlay.show();
-    }
-
-    $('#aorp-search-input').on('input', function(){
-        performSearch($(this).val());
-    });
-
-    $('#aorp-search-overlay').on('click', function(e){
-        if(e.target.id==='aorp-search-overlay'){
-            $(this).hide();
-            $('#aorp-search-input').val('');
-        }
-    });
-
-    $(document).on('keydown', function(e){
-        if(e.key==='Escape'){
-            $('#aorp-search-overlay').hide();
-            $('#aorp-search-input').val('');
-        }
-    });
-
     $('#aorp-close-cats').on('click', function(){
         $('.aorp-items').slideUp();
     });
@@ -82,4 +45,99 @@ jQuery(document).ready(function($){
     }else if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
         setDark(true);
     }
+});
+
+document.addEventListener('DOMContentLoaded', function(){
+    function normalizeText(s) {
+        return s.toLowerCase()
+            .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+            .replace(/\s+/g, ' ').trim();
+    }
+
+    const search = document.querySelector('#main-search');
+    const list = document.querySelector('.aorp-menu');
+    const items = [...list.querySelectorAll('.aorp-item')];
+    const groups = [...list.querySelectorAll('.aorp-items')];
+    const cats = [...list.querySelectorAll('.aorp-category')];
+
+    groups.forEach((grp, i) => grp.dataset.groupIndex = String(i));
+
+    items.forEach((el, idx) => {
+        if (!el.dataset.index) el.dataset.index = String(idx);
+        if (!el.dataset.number) {
+            const numEl = el.querySelector('.aorp-number');
+            if (numEl) el.dataset.number = (numEl.textContent.match(/\d+/)||['0'])[0];
+        }
+        if (!el.dataset.search) {
+            const name = el.querySelector('.aorp-title')?.textContent || '';
+            const desc = el.querySelector('.aorp-desc')?.textContent || '';
+            el.dataset.search = normalizeText(`${name} ${desc}`);
+        }
+        if (!el.dataset.group) {
+            el.dataset.group = el.closest('.aorp-items')?.dataset.groupIndex || '';
+        }
+    });
+
+    let t;
+    function applyFilter(qRaw) {
+        const q = normalizeText(qRaw);
+        let visible = [];
+        if (!q) {
+            cats.forEach(cat => cat.style.display = '');
+            groups.forEach(grp => grp.style.display = '');
+            items.forEach(el => {
+                el.style.display = '';
+                const parent = groups[+el.dataset.group];
+                if (parent) parent.appendChild(el);
+            });
+            groups.forEach(grp => {
+                [...grp.children].sort((a,b)=> (+a.dataset.index) - (+b.dataset.index)).forEach(ch=>grp.appendChild(ch));
+            });
+        } else {
+            cats.forEach(cat => cat.style.display = 'none');
+            groups.forEach(grp => grp.style.display = 'none');
+            items.forEach(el => {
+                const match = el.dataset.search.includes(q);
+                el.style.display = match ? '' : 'none';
+                if (match) visible.push(el);
+            });
+            visible.sort((a,b)=> (+a.dataset.number) - (+b.dataset.number));
+            visible.forEach(el => list.appendChild(el));
+        }
+
+        let empty = list.querySelector('.no-results');
+        if (!empty) {
+            empty = document.createElement('div');
+            empty.className = 'no-results';
+            empty.style.display = 'none';
+            empty.textContent = 'Keine Treffer';
+            list.appendChild(empty);
+        }
+        empty.style.display = (q && visible.length === 0) ? '' : 'none';
+    }
+
+    function setDimActive(on) {
+        document.getElementById('search-dim')?.classList.toggle('active', on);
+        document.querySelector('.main-search-wrap')?.classList.toggle('active', on);
+    }
+
+    search?.addEventListener('input', () => {
+        clearTimeout(t);
+        const val = search.value;
+        setDimActive(document.activeElement === search || val.trim().length > 0);
+        t = setTimeout(() => applyFilter(val), 100);
+    });
+
+    search?.addEventListener('focus', () => setDimActive(true));
+    search?.addEventListener('blur', () => {
+        if (!search.value.trim()) setDimActive(false);
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            if (!search.value.trim()) setDimActive(false);
+        }
+    });
+    document.getElementById('search-dim')?.addEventListener('click', () => search?.focus());
+
+    applyFilter(search?.value || '');
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,8 +1,8 @@
 /***** Frontend menu and dark mode styles */
 .aorp-menu{margin:1em 0}
 .aorp-note{margin-bottom:0.5em;font-weight:bold}
-#aorp-search-input{width:50%;max-width:400px;padding:0.5em 1em;border-radius:4px;border:1px solid #ccc;font-size:1rem;margin:0 auto;display:block;background:#fff;color:#000}
-.aorp-search-wrapper{text-align:center;position:relative;margin:2rem 0;z-index:10000}
+#main-search{width:50%;max-width:400px;padding:0.5em 1em;border-radius:4px;border:1px solid #ccc;font-size:1rem;margin:0 auto;display:block;background:#fff;color:#000}
+.main-search-wrap{text-align:center;position:relative;margin:2rem 0;z-index:10000}
 .aorp-close-cats{padding:0.5em 1em;background:#eee;color:#000;border:1px solid #ccc;border-radius:6px;cursor:pointer}
 body.aorp-dark .aorp-close-cats{background:#444;color:#fff;border-color:#666}
 .aorp-category{cursor:pointer;background:#eee;padding:0.5em;margin-bottom:0.5em;display:flex;align-items:center;min-height:40px;height:60px;line-height:1.2;box-sizing:border-box;border-radius:6px;box-shadow:0 1px 2px rgba(0,0,0,0.1)}
@@ -49,7 +49,7 @@ body.aorp-dark .aorp-ingredients-legend{background:#555;color:#fff;border-color:
         float:none;
         margin-right:0;
     }
-    .aorp-search-wrapper{
+    .main-search-wrap{
         width:100%;
     }
     .aorp-category{
@@ -57,11 +57,20 @@ body.aorp-dark .aorp-ingredients-legend{background:#555;color:#fff;border-color:
     }
 }
 
-/* Overlay search */
-#aorp-search-overlay{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);overflow:auto;z-index:9999;padding:2rem;text-align:center}
-#aorp-search-results .aorp-item{background:#f9f9f9;margin:0.5rem 0;padding:0.75rem 1rem;border-radius:4px;color:#000}
-#aorp-search-results .aorp-item-title{margin:0;font-size:1.1rem}
-#aorp-search-results .aorp-item-price{float:right;font-size:0.95rem;opacity:0.8}
+#mini-search, #mini-category { display: none !important; }
 
-body.aorp-dark #aorp-search-input{background:#333;color:#fff;border-color:#555}
-body.aorp-dark #aorp-search-results .aorp-item{background:#333;color:#fff}
+#main-search:focus {
+  outline: 3px solid rgba(0,0,0,.25);
+  box-shadow: 0 0 0 6px rgba(0,0,0,.08);
+}
+.main-search-wrap.active { z-index: 1001; position: relative; }
+#search-dim {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.35);
+  opacity: 0; pointer-events: none;
+  transition: opacity .2s ease;
+  z-index: 1000;
+}
+#search-dim.active { opacity: 1; pointer-events: auto; }
+
+body.aorp-dark #main-search{background:#333;color:#fff;border-color:#555}

--- a/includes/class-aorp-shortcodes.php
+++ b/includes/class-aorp-shortcodes.php
@@ -23,8 +23,8 @@ class AORP_Shortcodes {
             return;
         }
         self::$search_rendered = true;
-        echo '<div class="aorp-search-wrapper"><input type="text" id="aorp-search-input" placeholder="' . esc_attr__( 'Suche...', 'aorp' ) . '" /></div>';
-        echo '<div id="aorp-search-overlay"><div id="aorp-search-results"></div></div>';
+        echo '<div class="main-search-wrap"><input type="text" id="main-search" placeholder="' . esc_attr__( 'Suche...', 'aorp' ) . '" /></div>';
+        echo '<div id="search-dim" aria-hidden="true"></div>';
     }
     /**
      * Register shortcodes.

--- a/includes/frontend-search.php
+++ b/includes/frontend-search.php
@@ -18,12 +18,12 @@ function aio_frontend_search_filter( $output, $tag, $attr ) {
     }
 
     $terms = get_terms( $taxonomy, array( 'hide_empty' => false, 'orderby' => 'name', 'order' => 'ASC' ) );
-    $dropdown = '<select class="aio-category-filter"><option value="">' . esc_html__( 'Alle Kategorien', 'aorp' ) . '</option>';
+    $dropdown = '<select id="mini-category" class="aio-category-filter"><option value="">' . esc_html__( 'Alle Kategorien', 'aorp' ) . '</option>';
     foreach ( $terms as $term ) {
         $dropdown .= '<option value="' . esc_attr( $term->term_id ) . '">' . esc_html( $term->name ) . '</option>';
     }
     $dropdown .= '</select>';
-    $search = '<input type="text" class="aio-search-field" placeholder="' . esc_attr__( 'Suche', 'aorp' ) . '" />';
+    $search = '<input type="text" id="mini-search" class="aio-search-field" placeholder="' . esc_attr__( 'Suche', 'aorp' ) . '" />';
     $ui = '<div class="aio-search-filter-container">' . $search . ' ' . $dropdown . '</div>';
 
     return $ui . $output;


### PR DESCRIPTION
## Summary
- Hide legacy mini search and category filters and introduce prominent main search with dimming overlay.
- Style main search for focus highlight and overlay effect; ensure mini inputs are hidden.
- Add JavaScript filtering that normalizes text, sorts results by item number, and shows a no-results message.

## Testing
- ❌ `npm test` *(package.json missing)*
- ⚠️ `composer test` *(command not defined)*
- ✅ `php -l includes/frontend-search.php`
- ✅ `php -l includes/class-aorp-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0735e7b588329a62ee404dd4df101